### PR TITLE
EVALSYS-1475 Morpheus fixes for EvalSys

### DIFF
--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/AdministrateReportingProducer.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/AdministrateReportingProducer.java
@@ -16,6 +16,7 @@ package org.sakaiproject.evaluation.tool.producers;
 
 import org.sakaiproject.evaluation.logic.EvalCommonLogic;
 import org.sakaiproject.evaluation.logic.EvalSettings;
+import org.sakaiproject.evaluation.tool.renderers.NavBarRenderer;
 
 import uk.org.ponder.rsf.components.UICommand;
 import uk.org.ponder.rsf.components.UIContainer;
@@ -33,7 +34,12 @@ public class AdministrateReportingProducer extends EvalCommonProducer {
     public void setCommonLogic(EvalCommonLogic commonLogic) {
         this.commonLogic = commonLogic;
     }
-    
+
+    private NavBarRenderer navBarRenderer;
+    public void setNavBarRenderer(NavBarRenderer navBarRenderer) {
+        this.navBarRenderer = navBarRenderer;
+    }
+
     public String getViewID() {
         return VIEW_ID;
     }
@@ -46,7 +52,9 @@ public class AdministrateReportingProducer extends EvalCommonProducer {
             // Security check and denial
             throw new SecurityException("Non-admin users may not access this page");
         }
-        
+
+        navBarRenderer.makeNavBar(tofill, NavBarRenderer.NAV_ELEMENT, this.getViewID());
+
         // Breadcrumbs
         UIInternalLink.make(tofill, "summary-link", UIMessage.make("summary.page.title"),
                 new SimpleViewParameters(SummaryProducer.VIEW_ID));

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/ControlEvalAdminProducer.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/ControlEvalAdminProducer.java
@@ -17,10 +17,10 @@ package org.sakaiproject.evaluation.tool.producers;
 import java.util.List;
 
 import org.sakaiproject.evaluation.logic.EvalCommonLogic;
-import org.sakaiproject.evaluation.logic.EvalEvaluationService;
 import org.sakaiproject.evaluation.logic.EvalSettings;
 import org.sakaiproject.evaluation.logic.model.EvalUser;
 import org.sakaiproject.evaluation.model.EvalAdmin;
+import org.sakaiproject.evaluation.tool.renderers.NavBarRenderer;
 
 import uk.org.ponder.rsf.components.UIBranchContainer;
 import uk.org.ponder.rsf.components.UICommand;
@@ -29,162 +29,122 @@ import uk.org.ponder.rsf.components.UIELBinding;
 import uk.org.ponder.rsf.components.UIForm;
 import uk.org.ponder.rsf.components.UIInitBlock;
 import uk.org.ponder.rsf.components.UIInput;
-import uk.org.ponder.rsf.components.UIInternalLink;
 import uk.org.ponder.rsf.components.UIMessage;
 import uk.org.ponder.rsf.view.ComponentChecker;
-import uk.org.ponder.rsf.viewstate.SimpleViewParameters;
 import uk.org.ponder.rsf.viewstate.ViewParameters;
 
 public class ControlEvalAdminProducer extends EvalCommonProducer {
-	
+
 	public static String VIEW_ID = "control_eval_admin";
 	public String getViewID() {
 		return VIEW_ID;
 	}
-	
+
 	private EvalCommonLogic commonLogic;
 	public void setCommonLogic(EvalCommonLogic commonLogic) {
 		this.commonLogic = commonLogic;
 	}
-	
-	private EvalEvaluationService evaluationService;
-	public void setEvaluationService(EvalEvaluationService evaluationService) {
-		this.evaluationService = evaluationService;
-	}
-	
+
 	private EvalSettings settings;
-    public void setSettings(EvalSettings settings) {
-        this.settings = settings;
-    }
+	public void setSettings(EvalSettings settings) {
+		this.settings = settings;
+	}
+
+	private NavBarRenderer navBarRenderer;
+	public void setNavBarRenderer(NavBarRenderer navBarRenderer) {
+		this.navBarRenderer = navBarRenderer;
+	}
 
 	public void fill(UIContainer tofill, ViewParameters viewparams, ComponentChecker checker) {
-		
+
 		String currentUserId = commonLogic.getCurrentUserId();
 		boolean isAdmin = commonLogic.isUserAdmin(currentUserId);
 		boolean isEvalAdmin = commonLogic.isUserEvalAdmin(currentUserId);
-		
+
 		if (!isAdmin)
+		{
 			throw new SecurityException("Users who are not assigned as eval admins may not access this page");
-		
-		// TOP LINKS
-        UIInternalLink.make(tofill, "administrate-link",
-                UIMessage.make("administrate.page.title"),
-                new SimpleViewParameters(AdministrateProducer.VIEW_ID));
+		}
 
-        UIInternalLink.make(tofill, "summary-link", 
-                UIMessage.make("summary.page.title"), 
-                new SimpleViewParameters(SummaryProducer.VIEW_ID));
+		// Top links here
+		navBarRenderer.makeNavBar(tofill, NavBarRenderer.NAV_ELEMENT, this.getViewID());
 
-        // only show "My Evaluations", "My Templates", "My Items", "My Scales" and "My Email Templates" links if enabled
-        //boolean showMyToplinks = ((Boolean)evalSettings.get(EvalSettings.ENABLE_MY_TOPLINKS)).booleanValue(); // ALWAYS SHOW FOR ADMIN
-        boolean beginEvaluation = evaluationService.canBeginEvaluation(currentUserId);
-    	if (beginEvaluation) {
-    		UIInternalLink.make(tofill, "control-evaluations-link",
-    				UIMessage.make("controlevaluations.page.title"), 
-    				new SimpleViewParameters(ControlEvaluationsProducer.VIEW_ID));
-    	}
-    	
-    	UIInternalLink.make(tofill, "control-templates-link",
-    			UIMessage.make("controltemplates.page.title"), 
-    			new SimpleViewParameters(ControlTemplatesProducer.VIEW_ID));
+		UIMessage.make(tofill, "control-eval-admin-note", "controlevaladmin.page.note");
 
-    	if (!((Boolean) settings.get(EvalSettings.DISABLE_ITEM_BANK))) {
-    		UIInternalLink.make(tofill, "control-items-link",
-    				UIMessage.make("controlitems.page.title"),
-    				new SimpleViewParameters(ControlItemsProducer.VIEW_ID));
-    	}
-
-    	UIInternalLink.make(tofill, "control-scales-link",
-    			UIMessage.make("controlscales.page.title"),
-    			new SimpleViewParameters(ControlScalesProducer.VIEW_ID));
-
-    	UIInternalLink.make(tofill, "control-emailtemplates-link",
-    			UIMessage.make("controlemailtemplates.page.title"),
-    			new SimpleViewParameters(ControlEmailTemplatesProducer.VIEW_ID));
-		
-    	UIMessage.make(tofill, "control-eval-admin-title", "controlevaladmin.page.title");
-    	UIMessage.make(tofill, "control-eval-admin-note", "controlevaladmin.page.note");
-    	
 		UIForm evalAdminForm = UIForm.make(tofill, "eval-admin-form");
 		String evalAdminBean = "evalAdminBean.";
-		
+
 		// get the list of eval admins and their corresponding user information (in the form of EvalUser objects)
 		List<EvalAdmin> evalAdminList = commonLogic.getEvalAdmins();
 		int numEvalAdmins = evalAdminList.size();
 		String[] evalAdminIds = new String[numEvalAdmins];
 		String[] assignorIds = new String[numEvalAdmins];
-		
+
 		for (int i = 0; i < numEvalAdmins; i ++) {
 			EvalAdmin evalAdmin = evalAdminList.get(i);
 			evalAdminIds[i] = evalAdmin.getUserId();
 			assignorIds[i] = evalAdmin.getAssignorUserId();
 		}
-		
+
 		List<EvalUser> evalUserList = commonLogic.getEvalUsersByIds(evalAdminIds);
 		List<EvalUser> assignorList = commonLogic.getEvalUsersByIds(assignorIds);
-		
+
 		// render table headers
 		UIMessage.make(evalAdminForm, "user-info-header", "controlevaladmin.user.info.header");
 		UIMessage.make(evalAdminForm, "assignor-info-header", "controlevaladmin.assignor.info.header");
 		UIMessage.make(evalAdminForm, "actions-header", "controlevaladmin.actions.header");
-		
+
 		// display each eval admin's name, user eid, assignor, assign date, and a button to unassign them
 		for (int i = 0; i < numEvalAdmins; i ++) {
-			
+
 			EvalAdmin evalAdmin = evalAdminList.get(i);
 			EvalUser user = evalUserList.get(i);
 			EvalUser assignor = assignorList.get(i);
-			
+
 			UIBranchContainer userBranch = UIBranchContainer.make(evalAdminForm, "eval-admin:", String.valueOf(i));
 			UIMessage.make(userBranch, "user-info", "controlevaladmin.user.info", new Object[] { user.displayName, user.username });
 			UIMessage.make(userBranch, "assignor-info", "controlevaladmin.assignor.info", new Object[] { assignor.username, evalAdmin.getAssignDate() });
-			
+
 			// display unassign button if it is not the current user (i.e. users cannot unassign themselves)
 			// NOTE: in the case of only one admin, that admin is the current user. thus, unassign is made unavailable by this condition
 			if (!currentUserId.equals(evalAdmin.getUserId())) {
 				UICommand unassignButton = UICommand.make(userBranch, "unassign-button", UIMessage.make("controlevaladmin.unassign.button"), evalAdminBean + "unassignEvalAdmin");
 				unassignButton.parameters.add(new UIELBinding(evalAdminBean + "userId", evalAdmin.getUserId()));
 			}
-			
 		}
-		
+
 		// render an input and button to assign a user as an eval admin
 		UIMessage.make(evalAdminForm, "user-eid-label", "controlevaladmin.user.eid.label");
 		UIInput.make(evalAdminForm, "user-eid-input", evalAdminBean + "userEid");
 		UICommand.make(evalAdminForm, "assign-button", UIMessage.make("controlevaladmin.assign.button"), evalAdminBean + "assignEvalAdmin");
-		
+
 		// sakai admins table
 		UIMessage.make(evalAdminForm, "sakai-admins-header", "controlevaladmin.sakai.admins.header");
-		
+
 		// render sakai admin access status and toggle button, as well as sakai admin list
 		if ((Boolean) settings.get(EvalSettings.ENABLE_SAKAI_ADMIN_ACCESS)) { // sakai admin access is enabled
-			
+
 			UIMessage.make(evalAdminForm, "sakai-admin-access-status", "controlevaladmin.sakai.admin.access.status.enabled");
-			
+
 			// only eval admins can disable sakai admin access
 			if (isEvalAdmin)
+			{
 				UICommand.make(evalAdminForm, "toggle-sakai-admin-access-button", UIMessage.make("controlevaladmin.disable.sakai.admin.button"), evalAdminBean + "toggleSakaiAdminAccess");
-			
+			}
+
 			List<EvalUser> sakaiAdminList = commonLogic.getSakaiAdmins();
-			
 			for (int i = 0; i < sakaiAdminList.size(); i ++) {
-				
+
 				EvalUser sakaiAdmin = sakaiAdminList.get(i);
-				
 				UIBranchContainer sakaiAdminRowBranch = UIBranchContainer.make(evalAdminForm, "sakai-admin:", String.valueOf(i));
 				UIMessage.make(sakaiAdminRowBranch, "sakai-admin-info", "controlevaladmin.user.info", new Object[] { sakaiAdmin.displayName, sakaiAdmin.username });
-				
 			}
-			
 		}
-		
 		else { // sakai admin access is disabled
 			UIMessage.make(evalAdminForm, "sakai-admin-access-status", "controlevaladmin.sakai.admin.access.status.disabled");
 			UICommand.make(evalAdminForm, "toggle-sakai-admin-access-button", UIMessage.make("controlevaladmin.enable.sakai.admin.button"), evalAdminBean + "toggleSakaiAdminAccess");
 		}
-		
+
 		UIInitBlock.make(tofill, "init-js", "EvalSystem.initEvalAdminView", new Object[] {});
-		
 	}
-	
 }

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/ModifyItemProducer.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/ModifyItemProducer.java
@@ -644,6 +644,8 @@ public class ModifyItemProducer extends EvalCommonProducer implements ViewParams
         if (saveBinding != null) {
             UICommand.make(form, "save-item-action", UIMessage.make("modifyitem.save.button"), saveBinding);
         }
+
+        UICommand.make( form, "cancel-button", UIMessage.make( "general.cancel.button" ) );
     }
 
 

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/RemoveItemProducer.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/RemoveItemProducer.java
@@ -69,19 +69,12 @@ public class RemoveItemProducer extends EvalCommonProducer implements ViewParams
         this.itemRenderer = itemRenderer;
     }
 
-    private NavBarRenderer navBarRenderer;
-    public void setNavBarRenderer(NavBarRenderer navBarRenderer) {
-		this.navBarRenderer = navBarRenderer;
-	}
-    
     /* (non-Javadoc)
      * @see uk.org.ponder.rsf.view.ComponentProducer#fillComponents(uk.org.ponder.rsf.components.UIContainer, uk.org.ponder.rsf.viewstate.ViewParameters, uk.org.ponder.rsf.view.ComponentChecker)
      */
     public void fill(UIContainer tofill, ViewParameters viewparams, ComponentChecker checker) {
 
         UIMessage.make(tofill, "page-title", "removeitem.page.title");
-
-        navBarRenderer.makeNavBar(tofill, NavBarRenderer.NAV_ELEMENT, this.getViewID());
 
         // get templateItem to preview from VPs
         ItemViewParameters itemViewParams = (ItemViewParameters) viewparams;

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/RemoveItemProducer.java
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/producers/RemoveItemProducer.java
@@ -154,6 +154,7 @@ public class RemoveItemProducer extends EvalCommonProducer implements ViewParams
             deleteCommand.parameters.add(new UIELBinding(beanBinding + "itemId", item.getId()));
         }
 
+        UICommand.make( form, "cancel-button", UIMessage.make( "general.cancel.button" ) );
     }
 
     /* (non-Javadoc)

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/requestContext.xml
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/requestContext.xml
@@ -627,7 +627,6 @@
             ref="org.sakaiproject.evaluation.logic.EvalAuthoringService" />
         <property name="itemRenderer"
             ref="org.sakaiproject.evaluation.tool.renderers.ItemRenderer" />
-		<property name="navBarRenderer" ref="navBarRenderer" />	
     </bean>
 
 

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/requestContext.xml
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/requestContext.xml
@@ -380,6 +380,7 @@
         <property name="commonProducerBean" ref="org.sakaiproject.evaluation.tool.CommonProducerBean" />
         <property name="commonLogic"
             ref="org.sakaiproject.evaluation.logic.EvalCommonLogic" />
+        <property name="navBarRenderer" ref="navBarRenderer" />
     </bean>
 
     <bean class="org.sakaiproject.evaluation.tool.producers.AdministrateSearchProducer">

--- a/sakai-evaluation-tool/src/webapp/WEB-INF/requestContext.xml
+++ b/sakai-evaluation-tool/src/webapp/WEB-INF/requestContext.xml
@@ -467,10 +467,9 @@
         <property name="commonProducerBean" ref="org.sakaiproject.evaluation.tool.CommonProducerBean" />
         <property name="commonLogic"
             ref="org.sakaiproject.evaluation.logic.EvalCommonLogic" />
-        <property name="evaluationService"
-            ref="org.sakaiproject.evaluation.logic.EvalEvaluationService" />
         <property name="settings" 
             ref="org.sakaiproject.evaluation.logic.EvalSettings" />
+        <property name="navBarRenderer" ref="navBarRenderer" />
     </bean>
 	
 	<bean class="org.sakaiproject.evaluation.tool.producers.ModifyHierarchyNodePermsProducer">

--- a/sakai-evaluation-tool/src/webapp/component-templates/hierarchy_controls.html
+++ b/sakai-evaluation-tool/src/webapp/component-templates/hierarchy_controls.html
@@ -48,7 +48,7 @@
     </script>
 	<div rsf:id="selectColumnCheckboxes"/>
 	<input id="nodeClicked" name="nodeClicked" type="hidden"/>
-    <table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+    <table class="evalsysTable">
         <thead>
             <tr>
                 <th rsf:id="node-metadata-header" style="display: none"></th>
@@ -66,7 +66,7 @@
                     <input id="node-id-input" rsf:id="node-id-input" type="hidden" value="TheNodeID" />
                     <input id="parent-id-input" rsf:id="parent-id-input" type="hidden" value="TheParentID" />
                 </td>
-                <td rsf:id="row-data" style="text-indent:0em" colspan="4"><!-- used for displaying long text data, not rendered for normal nodes --></td>
+                <td rsf:id="row-data" class="noTextIndent" colspan="4"><!-- used for displaying long text data, not rendered for normal nodes --></td>
                 <td rsf:id="node-select-cell" width="10%">
                     <input rsf:id="select-checkbox" class="evalgroupselect" type="checkbox" />
                     <input rsf:id="select-checkbox-hide" class="evalgroupselect" type="checkbox" onchange="clickHierarchyCheckbox(this);" />
@@ -81,27 +81,27 @@
                 <td rsf:id="nodes-cell">
                     <span rsf:id="number-children">3</span>
                     &nbsp;
-                    <a rsf:id="add-child-link" href="" style="font-size: 0.9em;">Add</a>
-                    <a rsf:id="modify-node-link" href="" style="font-size: 0.9em;">Modify</a>
+                    <a rsf:id="add-child-link" href="">Add</a>
+                    <a rsf:id="modify-node-link" href="">Modify</a>
                     <form rsf:id="remove-node-form">
                         <input type="submit" rsf:id="remove-node-button" value="Remove"
-                            style="font-size:0.9em;height:2.1em;margin:0px;padding:0px;" />
+                            style="height:2.1em;margin:0px;padding:0px;" />
                     </form>
                 </td>
                 <td rsf:id="groups-cell">
                     <span rsf:id="assign-group-count">67</span>
                     &nbsp;
-                    <a rsf:id="assign-groups-link" href="" style="font-size: 0.9em;">Assign Groups</a>
+                    <a rsf:id="assign-groups-link" href="">Assign Groups</a>
                 </td>
                 <td rsf:id="users-cell">
                     <span rsf:id="assign-user-count">67</span>
                     &nbsp;
-                    <a rsf:id="assign-users-link" href="" style="font-size: 0.9em;">Assign Users</a>
+                    <a rsf:id="assign-users-link" href="">Assign Users</a>
                 </td>
                 <td rsf:id="rules-cell">
                     <span rsf:id="assign-rule-count">67</span>
                     &nbsp;
-                    <a rsf:id="assign-rules-link" href="" style="font-size: 0.9em;">Assign Rules</a>
+                    <a rsf:id="assign-rules-link" href="">Assign Rules</a>
                 </td>
             </tr>
         </tbody>

--- a/sakai-evaluation-tool/src/webapp/component-templates/hierarchy_controls.html
+++ b/sakai-evaluation-tool/src/webapp/component-templates/hierarchy_controls.html
@@ -80,7 +80,6 @@
                 </td>
                 <td rsf:id="nodes-cell">
                     <span rsf:id="number-children">3</span>
-                    &nbsp;
                     <a rsf:id="add-child-link" href="">Add</a>
                     <a rsf:id="modify-node-link" href="">Modify</a>
                     <form rsf:id="remove-node-form">
@@ -90,17 +89,14 @@
                 </td>
                 <td rsf:id="groups-cell">
                     <span rsf:id="assign-group-count">67</span>
-                    &nbsp;
                     <a rsf:id="assign-groups-link" href="">Assign Groups</a>
                 </td>
                 <td rsf:id="users-cell">
                     <span rsf:id="assign-user-count">67</span>
-                    &nbsp;
                     <a rsf:id="assign-users-link" href="">Assign Users</a>
                 </td>
                 <td rsf:id="rules-cell">
                     <span rsf:id="assign-rule-count">67</span>
-                    &nbsp;
                     <a rsf:id="assign-rules-link" href="">Assign Rules</a>
                 </td>
             </tr>

--- a/sakai-evaluation-tool/src/webapp/component-templates/render_admin_box.html
+++ b/sakai-evaluation-tool/src/webapp/component-templates/render_admin_box.html
@@ -32,7 +32,7 @@
       </h4>
       <div class="innerPanel">
         <form rsf:id="evalAdminForm" action="evaluation_settings.html">
-          <table cellspacing="0" cellpadding="0" width="99%" class="listHier  lines nolines" border="0">
+          <table width="99%" class="evalsysTable">
             <thead>
               <tr>
                 <th class="column" rsf:id="msg=summary.evaluations.evaluation.title">Evaluation</th>

--- a/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
+++ b/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
@@ -1507,64 +1507,51 @@ a.less {
   margin-left: 1em;
 }
 
-.evalAdminTable {
-  border: 1px solid #eee;
-  margin-top: 20px;
-}
-
-.evalAdminTable thead tr {
-  background: #ccc;
-}
-
-.evalAdminTable td {
-  padding: 0 20px;
-}
-
 .column {
   width: 25%;
 }
 
 /* hierarchy node perms page, target hierarchy rules UI also */
-table#user-perms-table, table#rules-table {
+table#user-perms-table, table#rules-table, table#evalAdmin-table {
   margin: 2em 0;
   border: 1px solid #ccc;
 }
 
-table#user-perms-table thead, table#rules-table thead {
+table#user-perms-table thead, table#rules-table thead, table#evalAdmin-table thead {
   background: #aaa;
 }
 
-table#user-perms-table thead tr th, table#rules-table thead tr th {
+table#user-perms-table thead tr th, table#rules-table thead tr th, table#evalAdmin-table thead tr th {
   text-align: center !important;
 }
 
-table#user-perms-table tr, table#rules-table tr {
+table#user-perms-table tr, table#rules-table tr, table#evalAdmin-table tr {
   padding: 10px 0;
 }
 
-table#user-perms-table tbody tr:nth-child(2n), table#rules-table tbody tr:nth-child(2n) {
+table#user-perms-table tbody tr:nth-child(2n), table#rules-table tbody tr:nth-child(2n), table#evalAdmin-table tbody tr:nth-child(2n) {
   background: #eee;
 }
 
-table#user-perms-table td, table#rules-table td {
+table#user-perms-table td, table#rules-table td, table#evalAdmin-table td {
   padding: 10px;
 }
 
-table#user-perms-table td.userInfo, table#rules-table td.userInfo {
+table#user-perms-table td.userInfo, table#rules-table td.userInfo, table#evalAdmin-table td.userInfo {
   text-align: center;
 }
 
-table#user-perms-table td.actions, table#rules-table td.actions {
+table#user-perms-table td.actions, table#rules-table td.actions, table#evalAdmin-table td.actions {
   text-align: center;
 }
 
-table#user-perms-table td.userPerms > span:nth-child(2n+1), table#rules-table td.userPerms > span:nth-child(2n+1) {
+table#user-perms-table td.userPerms > span:nth-child(2n+1), table#rules-table td.userPerms > span:nth-child(2n+1), table#evalAdmin-table td.userPerms > span:nth-child(2n+1) {
   clear: left;
   float: left;
   width: 140px;
 }
 
-table#user-perms-table td.userPerms > span:nth-child(2n), table#rules-table td.userPerms > span:nth-child(2n) {
+table#user-perms-table td.userPerms > span:nth-child(2n), table#rules-table td.userPerms > span:nth-child(2n), table#evalAdmin-table td.userPerms > span:nth-child(2n) {
   float: left;
 }
 

--- a/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
+++ b/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
@@ -1042,6 +1042,13 @@ form {
   padding: .2em;
   color: orange;
   margin-left: 1em;
+  display: inline;
+  width: auto;
+  border: none;
+}
+
+.checkbox input[type="checkbox"] {
+  margin-left: auto;
 }
 
 label.block {

--- a/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
+++ b/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
@@ -1011,7 +1011,6 @@ form {
   font-family: verdana,arial;
   font-size: 100%;
   color: #27d;
-  padding: .2em .3em 1px 0;
   white-space: nowrap;
 }
 

--- a/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
+++ b/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
@@ -1516,46 +1516,56 @@ a.less {
 }
 
 /* hierarchy node perms page, target hierarchy rules UI also */
-table#user-perms-table, table#rules-table, table#evalAdmin-table {
+table#user-perms-table, table#rules-table, table#evalAdmin-table, table#groups-table,
+table#hierarchy-table{
   margin: 2em 0;
   border: 1px solid #ccc;
 }
 
-table#user-perms-table thead, table#rules-table thead, table#evalAdmin-table thead,  {
+table#user-perms-table thead, table#rules-table thead, table#evalAdmin-table thead, table#groups-table thead,
+table#hierarchy-table thead {
   background: #aaa;
 }
 
-table#user-perms-table thead tr th, table#rules-table thead tr th, table#evalAdmin-table thead tr th {
+table#user-perms-table thead tr th, table#rules-table thead tr th, table#evalAdmin-table thead tr th, table#groups-table thead tr th,
+table#hierarchy-table thead tr th {
   text-align: center !important;
 }
 
-table#user-perms-table tr, table#rules-table tr, table#evalAdmin-table tr {
+table#user-perms-table tr, table#rules-table tr, table#evalAdmin-table tr, table#groups-table tr,
+table#hierarchy-table tr {
   padding: 10px 0;
 }
 
-table#user-perms-table tbody tr:nth-child(2n), table#rules-table tbody tr:nth-child(2n), table#evalAdmin-table tbody tr:nth-child(2n) {
+table#user-perms-table tbody tr:nth-child(2n), table#rules-table tbody tr:nth-child(2n), table#evalAdmin-table tbody tr:nth-child(2n), table#groups-table tbody tr:nth-child(2n),
+table#hierarchy-table tbody tr:nth-child(2n) {
   background: #eee;
 }
 
-table#user-perms-table td, table#rules-table td, table#evalAdmin-table td {
+table#user-perms-table td, table#rules-table td, table#evalAdmin-table td, table#groups-table td,
+table#hierarchy-table td {
   padding: 10px;
 }
 
-table#user-perms-table td.userInfo, table#rules-table td.userInfo, table#evalAdmin-table td.userInfo {
+table#user-perms-table td.userInfo, table#rules-table td.userInfo, table#evalAdmin-table td.userInfo, table#groups-table td.userInfo,
+table#hierarchy-table td.userInfo {
   text-align: center;
 }
 
-table#user-perms-table td.actions, table#rules-table td.actions, table#evalAdmin-table td.actions {
+table#user-perms-table td.actions, table#rules-table td.actions, table#evalAdmin-table td.actions, table#groups-table td.actions,
+table#hierarchy-table td.actions {
   text-align: center;
 }
 
-table#user-perms-table td.userPerms > span:nth-child(2n+1), table#rules-table td.userPerms > span:nth-child(2n+1), table#evalAdmin-table td.userPerms > span:nth-child(2n+1) {
+table#user-perms-table td.userPerms > span:nth-child(2n+1), table#rules-table td.userPerms > span:nth-child(2n+1), table#evalAdmin-table td.userPerms > span:nth-child(2n+1), table#groups-table td.userPerms > span:nth-child(2n+1),
+table#hierarchy-table td.userPerms > span:nth-child(2n+1) {
   clear: left;
   float: left;
   width: 140px;
 }
 
-table#user-perms-table td.userPerms > span:nth-child(2n), table#rules-table td.userPerms > span:nth-child(2n), table#evalAdmin-table td.userPerms > span:nth-child(2n) {
+table#user-perms-table td.userPerms > span:nth-child(2n), table#rules-table td.userPerms > span:nth-child(2n), table#evalAdmin-table td.userPerms > span:nth-child(2n), table#groups-table td.userPerms > span:nth-child(2n),
+table#hierarchy-table td.userPerms > span:nth-child(2n) {
   float: left;
 }
 

--- a/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
+++ b/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
@@ -2139,3 +2139,9 @@ li.exportIndividual {
 ol.itemListEval span.label {
     color: #000 !important;
 }
+
+.instructionText {
+    color: #555;
+    line-height: 1.3em;
+    margin: 0.5em 0;
+}

--- a/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
+++ b/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
@@ -361,8 +361,7 @@ ol.summaryEvaluateList {
 .scaleOuterList {
   width: 60%;
   padding: 0;
-  margin: 1em 0;
-  list-style: decimal;
+  list-style: none;
 }
 
 .scaleInnerList {
@@ -378,7 +377,6 @@ ol.summaryEvaluateList {
 }
 
 .scaleTitleLine {
-  height: 1.5em;
   overflow: hidden;
   background: #eee;
   padding: 0.3em;
@@ -1523,7 +1521,7 @@ table#user-perms-table, table#rules-table, table#evalAdmin-table {
   border: 1px solid #ccc;
 }
 
-table#user-perms-table thead, table#rules-table thead, table#evalAdmin-table thead {
+table#user-perms-table thead, table#rules-table thead, table#evalAdmin-table thead,  {
   background: #aaa;
 }
 

--- a/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
+++ b/sakai-evaluation-tool/src/webapp/content/css/evaluation_base.css
@@ -213,6 +213,8 @@ div.scaleDesc {
   padding: .5em 0;
   background: #ffe;
   margin: 1em 0;
+  clear: both;
+  height: 1.5em;
 }
 
 .navIntraTool .breadCrumb {
@@ -225,6 +227,7 @@ div.scaleDesc {
   background: #ffffee url(../images/breadSep.gif) center right no-repeat;
   padding: 0 1.2em 0  .5em;
   margin: 0;
+  float: left;
 }
 
 .breadCrumb li:first-child {
@@ -234,6 +237,16 @@ div.scaleDesc {
 .breadCrumb li.lastCrumb {
   display: inline;
   background-image: none;
+  float: right;
+}
+
+.breadCrumb li.lastCrumbNoFloat {
+  display: inline;
+  background-image: none;
+}
+
+.inlineBlockForm {
+    display: inline-block;
 }
 
 /*sub-breadcrumb for wizards deep inside of a workflow*/
@@ -1515,66 +1528,76 @@ a.less {
   width: 25%;
 }
 
-/* hierarchy node perms page, target hierarchy rules UI also */
-table#user-perms-table, table#rules-table, table#evalAdmin-table, table#groups-table,
-table#hierarchy-table{
+/* hierarchy */
+table.evalsysTable {
   margin: 2em 0;
   border: 1px solid #ccc;
 }
 
-table#user-perms-table thead, table#rules-table thead, table#evalAdmin-table thead, table#groups-table thead,
-table#hierarchy-table thead {
+table.evalsysTable thead {
   background: #aaa;
 }
 
-table#user-perms-table thead tr th, table#rules-table thead tr th, table#evalAdmin-table thead tr th, table#groups-table thead tr th,
-table#hierarchy-table thead tr th {
+table.evalsysTable thead tr th {
   text-align: center !important;
 }
 
-table#user-perms-table tr, table#rules-table tr, table#evalAdmin-table tr, table#groups-table tr,
-table#hierarchy-table tr {
+table.evalsysTable tr {
   padding: 10px 0;
 }
 
-table#user-perms-table tbody tr:nth-child(2n), table#rules-table tbody tr:nth-child(2n), table#evalAdmin-table tbody tr:nth-child(2n), table#groups-table tbody tr:nth-child(2n),
-table#hierarchy-table tbody tr:nth-child(2n) {
+table.evalsysTable tbody tr:nth-child(2n) {
   background: #eee;
 }
 
-table#user-perms-table td, table#rules-table td, table#evalAdmin-table td, table#groups-table td,
-table#hierarchy-table td {
+table.evalsysTable tbody tr td.noTextIndent {
+    text-indent: 0em;
+}
+
+table.evalsysTable tbody tr td a.inlineLink {
+    font-size: 0.9em;
+}
+
+table.evalsysTable td {
   padding: 10px;
 }
 
-table#user-perms-table td.userInfo, table#rules-table td.userInfo, table#evalAdmin-table td.userInfo, table#groups-table td.userInfo,
-table#hierarchy-table td.userInfo {
+table.evalsysTable td.alignCenter, table.evalsysTable td.actions {
   text-align: center;
 }
 
-table#user-perms-table td.actions, table#rules-table td.actions, table#evalAdmin-table td.actions, table#groups-table td.actions,
-table#hierarchy-table td.actions {
-  text-align: center;
-}
-
-table#user-perms-table td.userPerms > span:nth-child(2n+1), table#rules-table td.userPerms > span:nth-child(2n+1), table#evalAdmin-table td.userPerms > span:nth-child(2n+1), table#groups-table td.userPerms > span:nth-child(2n+1),
-table#hierarchy-table td.userPerms > span:nth-child(2n+1) {
+table.evalsysTable td.checkboxes > span:nth-child(2n+1) {
   clear: left;
   float: left;
   width: 140px;
 }
 
-table#user-perms-table td.userPerms > span:nth-child(2n), table#rules-table td.userPerms > span:nth-child(2n), table#evalAdmin-table td.userPerms > span:nth-child(2n), table#groups-table td.userPerms > span:nth-child(2n),
-table#hierarchy-table td.userPerms > span:nth-child(2n) {
+table.evalsysTable td.checkboxes > span:nth-child(2n) {
   float: left;
 }
 
-table#rules-table .actions .saveButton {
+table.evalsysTable .actions .saveButton {
   margin-right: 5px;
 }
 
-table#rules-table .userInfo select {
+table.evalsysTable .alignCenter select {
   margin: 0 5px 0 0;
+}
+
+div.action {
+  margin-bottom: 5px;
+}
+
+div.action span.cancelButton input[type="submit"], div.action span.cancelButton input[type="button"]{
+  float:right;
+}
+
+div.alertMessage ul {
+  margin:0px;
+}
+
+p.alertMessage ul {
+  margin:0px;
 }
 
 table tr.node td.node-1 {

--- a/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
+++ b/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
@@ -1035,6 +1035,13 @@ form {
   padding: .2em;
   color: orange;
   margin-left: 1em;
+  display: inline;
+  width: auto;
+  border: none;
+}
+
+.checkbox input[type="checkbox"] {
+  margin-left: auto;
 }
 
 label.block {

--- a/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
+++ b/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
@@ -1496,19 +1496,6 @@ a.less {
   margin-left: 1em;
 }
 
-.evalAdminTable {
-  border: 1px solid #eee;
-  margin-top: 20px;
-}
-
-.evalAdminTable thead tr {
-  background: #ccc;
-}
-
-.evalAdminTable td {
-  padding: 0 20px;
-}
-
 .column {
   width: 25%;
 }

--- a/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
+++ b/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
@@ -347,8 +347,7 @@ ol.summaryEvaluateList {
 .scaleOuterList {
   width: 60%;
   padding: 0;
-  margin: 1em 0;
-  list-style: decimal;
+  list-style: none;
 }
 
 .scaleInnerList {
@@ -364,7 +363,6 @@ ol.summaryEvaluateList {
 }
 
 .scaleTitleLine {
-  height: 1.5em;
   overflow: hidden;
   background: #eee;
   padding: 0.3em;

--- a/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
+++ b/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
@@ -199,6 +199,8 @@ div.scaleDesc {
   padding: .5em 0;
   background: #ffe;
   margin: 1em 0;
+  clear: both;
+  height: 1.5em;
 }
 
 .navIntraTool .breadCrumb {
@@ -211,6 +213,7 @@ div.scaleDesc {
   background: #ffffee url(../images/breadSep.gif) center right no-repeat;
   padding: 0 1.2em 0  .5em;
   margin: 0;
+  float: left;
 }
 
 .breadCrumb li:first-child {
@@ -218,6 +221,12 @@ div.scaleDesc {
 }
 
 .breadCrumb li.lastCrumb {
+  display: inline;
+  background-image: none;
+  float: right;
+}
+
+.breadCrumb li.lastCrumbNoFloat {
   display: inline;
   background-image: none;
 }
@@ -1504,44 +1513,76 @@ a.less {
   width: 25%;
 }
 
-/* hierarchy node perms page */
-table#user-perms-table {
-  margin: 15px 0;
+/* hierarchy */
+table.evalsysTable {
+  margin: 2em 0;
   border: 1px solid #ccc;
 }
 
-table#user-perms-table thead {
+table.evalsysTable thead {
   background: #aaa;
 }
 
-table#user-perms-table tr {
+table.evalsysTable thead tr th {
+  text-align: center !important;
+}
+
+table.evalsysTable tr {
   padding: 10px 0;
 }
 
-table#user-perms-table tbody tr:nth-child(2n) {
+table.evalsysTable tbody tr:nth-child(2n) {
   background: #eee;
 }
 
-table#user-perms-table td {
+table.evalsysTable tbody tr td.noTextIndent {
+    text-indent: 0em;
+}
+
+table.evalsysTable tbody tr td a.inlineLink {
+    font-size: 0.9em;
+}
+
+table.evalsysTable td {
   padding: 10px;
 }
 
-table#user-perms-table td.userInfo {
+table.evalsysTable td.alignCenter, table.evalsysTable td.actions {
   text-align: center;
 }
 
-table#user-perms-table td.actions {
-  text-align: center;
-}
-
-table#user-perms-table td.userPerms > span:nth-child(2n+1) {
+table.evalsysTable td.checkboxes > span:nth-child(2n+1) {
   clear: left;
   float: left;
   width: 140px;
 }
 
-table#user-perms-table td.userPerms > span:nth-child(2n) {
+table.evalsysTable td.checkboxes > span:nth-child(2n) {
   float: left;
+}
+
+table.evalsysTable .actions .saveButton {
+  margin-right: 5px;
+}
+
+table.evalsysTable .alignCenter select {
+  margin: 0 5px 0 0;
+}
+
+div.action {
+  margin-bottom: 5px;
+}
+
+div.action span.cancelButtoncancel input[type="submit"], div.action span.cancelButtoncancel input[type="button"]{
+  float:right;
+}
+
+div.alertMessage ul {
+  margin:0px;
+}
+
+p.alertMessage ul {
+  margin:0px;
 }
 
 /* tablesorter - mostly on the dashboard */

--- a/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
+++ b/sakai-evaluation-tool/src/webapp/content/css/scss/_evaluation_base_copy.scss
@@ -1005,7 +1005,6 @@ form {
   font-family: verdana,arial;
   font-size: 100%;
   color: #27d;
-  padding: .2em .3em 1px 0;
   white-space: nowrap;
 }
 .navIntraTool input.makeLink {

--- a/sakai-evaluation-tool/src/webapp/content/js/evalAjax.js
+++ b/sakai-evaluation-tool/src/webapp/content/js/evalAjax.js
@@ -465,7 +465,7 @@ function updateControlItemsTotal() {
                 if ($('div.itemRowBlock[id$=:itemRowBlock:'+options.id+':]').parents('.itemTableBlock').find('div.itemRowBlock').get().length <= 2) {
                     var error = '<div class="itemOperationsEnabled">' +
                                 '<img src="/library/image/sakai/cancelled.gif"/>' +
-                                '<span class="instruction"></span>'+evalTemplateUtils.messageLocator('modifytemplate.group.cannot.delete.item')+' <a href="#" id="closeItemOperationsEnabled">x</a></div>';
+                                '<span class="instructionText"></span>'+evalTemplateUtils.messageLocator('modifytemplate.group.cannot.delete.item')+' <a href="#" id="closeItemOperationsEnabled">x</a></div>';
                     $(that).parents('.itemLine3').prepend(error).effect('highlight', 1000);
                     $('#closeItemOperationsEnabled').click(function() {
                         $(this).parent().slideUp('normal', function() {

--- a/sakai-evaluation-tool/src/webapp/content/js/facebox/facebox.css
+++ b/sakai-evaluation-tool/src/webapp/content/js/facebox/facebox.css
@@ -66,15 +66,14 @@
 }
 
 #facebox .header {
-	border-bottom: 1px solid #DDDDDD;
-  background: #FFFFEE
+  background: #FFFFEE;
   padding-bottom: 5px;
-	margin-bottom: 10px;
-	text-align: right;
-	margin-top: 0px;
-	margin-right: 0px;
-	margin-left: 0px;
-	padding: 5px;
+  margin-bottom: 10px;
+  text-align: right;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-left: 0px;
+  padding: 5px;
 }
 #facebox .titleHeader {
 	float: left;

--- a/sakai-evaluation-tool/src/webapp/content/js/reorderUtils.js
+++ b/sakai-evaluation-tool/src/webapp/content/js/reorderUtils.js
@@ -212,7 +212,7 @@ $(document).bind('list.warning', function(e, ui, option, extra, err){
        $("div.itemList").find('.itemOperationsEnabled').remove();
         var error = '<div class="itemOperationsEnabled">\
                         <img src="/library/image/sakai/cancelled.gif"/>\
-                        <span class="instruction">'+ err +'</span> <a href="#" id="closeItemOperationsEnabled">close</a></div>\
+                        <span class="instructionText">'+ err +'</span> <a href="#" id="closeItemOperationsEnabled">close</a></div>\
                         ';
         if(extra == 'block')
             item.parents('.itemLine3').prepend(error);

--- a/sakai-evaluation-tool/src/webapp/content/templates/admin_test_evalgroup_provider.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/admin_test_evalgroup_provider.html
@@ -37,11 +37,11 @@
 <ul class="breadCrumb">
    <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
    <li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-   <li rsf:id="page-title" class="lastCrumb">Test EvalGroup Provider</li>
+   <li rsf:id="page-title" class="lastCrumbNoFloat">Test EvalGroup Provider</li>
 </ul>
 
 <div rsf:id="message-for:*" class="alertMessage">
-   <ul style="margin:0px;">
+   <ul>
       <li>Message for user here</li>
    </ul>
 </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate.html
@@ -41,53 +41,53 @@
 
 <!--//gsilver: all in the same line, avoid wspace -->
 <div>
-	<ul class="breadCrumb"  style="clear:both;height:1.5em">
-		<li  style="float:left">
+	<ul class="breadCrumb">
+		<li>
 			<a rsf:id="summary-link" href="summary.html">Summary</a>
 		</li>
-		<li style="float:left" class="lastCrumb" rsf:id="administrate-title">Administrate</li>
-		<li style="float:right" class=" lastCrumb addItem">
+		<li rsf:id="administrate-title" class="lastCrumbNoFloat">Administrate</li>
+		<li class=" lastCrumb addItem">
 			<a rsf:id="test-evalgroupprovider-toplink" href="admin_test_evalgroup_provider.html" class="goToList">Test EvalGroupProvider</a>
 		</li>
-		<li style="float:right" class="lastCrumb">
+		<li class="lastCrumb">
 			<a rsf:id="control-eval-admin-toplink" href="control_eval_admin.html" class="goToList">Control Eval Admin</a>
 		</li>
-		<li style="float:right" class="lastCrumb">
+		<li class="lastCrumb">
 			<a rsf:id="control-email-toplink" href="control_email.html" class="goToList">Control Email</a>
 		</li>
-		<li style="float:right" class="lastCrumb">
+		<li class="lastCrumb">
 			<a rsf:id="control-import-toplink" href="control_import.html" class="goToList">Control Importing</a>
 		</li>
-		<li style="float:right" class="lastCrumb">
+		<li class="lastCrumb">
 			<a rsf:id="control-hierarchy-toplink" href="control_hierarchy.html" class="goToList">Control Hierarchy</a>
 		</li>
-		<li style="float:right" class="lastCrumb">
+		<li class="lastCrumb">
 			<a rsf:id="control-reporting-toplink" href="control_reporting.html" class="goToList">Control Reporting</a>
 		</li>
-        <li style="float:right" class="lastCrumb">
+        <li class="lastCrumb">
           <a rsf:id="control-import-settings-toplink" href="import_config.html" class="goToList">Import Configuration</a>
         </li>
-        <li style="float:right" class="lastCrumb">
+        <li class="lastCrumb">
           <a rsf:id="control-export-settings-toplink" href="administrate.html" class="goToList">Export Configuration</a>
         </li>
-		<li style="float:right" class="lastCrumb">
+		<li class="lastCrumb">
 			<!-- string added to bundle as administrate.top.control.search -->
 			<a rsf:id="control-administrate-search"  href="administrate_search.html" class="goToList">Search</a>
 		</li>
-		<li style="float:right" class="lastCrumb">
+		<li class="lastCrumb">
 			<a rsf:id="control-administrate-sync"  href="administrate_provider_sync.html" class="goToList">Sync Group Members</a>
 		</li>
 	</ul>
 </div>
 
 <div rsf:id="message-for:*" class="alertMessage">
-   <ul style="margin:0px;">
+   <ul>
       <li>Message for user here</li>
    </ul>
 </div>
 
 <p rsf:id="email-delivery" class="alertMessage">
-    <ul style="margin:0px;">
+    <ul>
         <li>Message re current email delivery setting here</li>
     </ul>
 </p>

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate.html
@@ -95,7 +95,7 @@
 <form rsf:id="basic-form" class="administrate-form" method="post">
 
     <h3 rsf:id="system-settings-header">System Settings</h3>
-    <p class="instruction" rsf:id="system-settings-instructions">
+    <p class="instructionText" rsf:id="system-settings-instructions">
         Note that the system settings mostly control whether something can happen at all.
         <br /><br />
         Settings in the evaluation can still be controlled on a per evaluation basis unless

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate_email.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate_email.html
@@ -52,7 +52,7 @@
                     Send <strong>one email per student per evaluation</strong>
                     </label>
                 </p>
-                <p rsf:id="msg=controlemail.individual.emails.explain" class="instruction textPanelFooter indnt3" style="padding: 3px;"> This will
+                <p rsf:id="msg=controlemail.individual.emails.explain" class="instructionText textPanelFooter indnt3" style="padding: 3px;"> This will
                     mean that Pat Student will get five emails if she has five evaluations. </p>
                 <fieldset class="visibleFS indnt3 emailtype1 emailTypeOptions" style="">
                     <legend>
@@ -113,7 +113,7 @@
                     <label rsf:id="email-type-choice-consolidated-label" for="emailtype2"> Send <strong>summary emails</strong>. The default
                         is to send one email per student per email template. </label>
                 </p>
-                <p rsf:id="msg=controlemail.consolidated.emails.explain" class="instruction textPanelFooter indnt3" style="padding: 3px;"> This will
+                <p rsf:id="msg=controlemail.consolidated.emails.explain" class="instructionText textPanelFooter indnt3" style="padding: 3px;"> This will
                     mean that if Pat Student has five evaluations of the same type she will get
                     one summary email about it. If she has two evaluations using the "Chemistry"
                     email template and four evaluations using the "Biology" email template, she
@@ -163,7 +163,7 @@
 						<div rsf:id="nextReminderDateDiv:" class="longtext indnt1">
 							<label rsf:id="msg=controlemail.next-reminder-date" for="nextReminderDate" class="block">Next reminder date/time </label>
 								<input rsf:id="nextReminderDate:" type="hidden" id="nextReminderDate" name="nextReminderDate" value="MM/DD/YYYY" size="15" maxlength="15"/>
-							<div rsf:id="msg=controlemail.setting-reminder-date" class="instruction textPanelFooter block indnt1">
+							<div rsf:id="msg=controlemail.setting-reminder-date" class="instructionText textPanelFooter block indnt1">
 								Evaluation ends on this date, no more responses after this date
 							</div>
 						</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate_email.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate_email.html
@@ -36,7 +36,7 @@
 	<div class="portletBody">
 		<div rsf:id="navIntraTool:" class="navIntraTool"></div>
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
   				<li>Message for user here</li>
 			</ul>
 		</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate_provider_sync.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate_provider_sync.html
@@ -76,7 +76,7 @@
                     style="border:1px solid #ccc;background:#fff; display:block;">
                     <input type="hidden" rsf:id="currentTab" id="currentTab" class="currentTab" value="0" />
                     <div style="padding:1em;">
-                        <p class="instruction"
+                        <p class="instructionText"
                             rsf:id="msg=administrate.sync.by_event.instruction"> Sync
                             memberships when the following happens </p>
                         <p class="longtext indnt1">
@@ -238,7 +238,7 @@
                     style="border:1px solid #ccc;background:#fff; display:block;">
                     <input type="hidden" rsf:id="currentTab" id="currentTab" class="currentTab" value="0" />
                     <div style="padding:1em;">
-                        <p rsf:id="msg=administrate.sync.quick_sync.states" class="instruction">
+                        <p rsf:id="msg=administrate.sync.quick_sync.states" class="instructionText">
                             Run quick sync on evaluations that are: </p>
                         <p class="checkbox">
                             <input rsf:id="quick_sync-state-partial"

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate_provider_sync.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate_provider_sync.html
@@ -39,18 +39,18 @@
         <!-- administrate_provider_sync.html -->
         <div rsf:id="navIntraTool:" class="navIntraTool"></div>
         <ul class="breadCrumb">
-            <li style="float: left">
+            <li>
                 <a rsf:id="summary-link" href="summary.html">Summary</a>
             </li>
-            <li style="float: left">
+            <li>
                 <a rsf:id="administrate-link" href="administrate.html">Administrate</a>
             </li>
-            <li class="lastCrumb">
+            <li class="lastCrumbNoFloat">
                 <span rsf:id="msg=administrate.sync.breadcrumb.title">Sync Group Members</span>
             </li>
         </ul>
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
                 <li>Message for user here</li>
             </ul>
         </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate_reporting.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate_reporting.html
@@ -35,14 +35,15 @@
 </head>
 <body>
 <div class="portletBody">
-    <ul class="breadCrumb" style="clear: both; height: 1.5em">
-        <li style="float: left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-        <li style="float: left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-        <li rsf:id="page-title" class="lastCrumb" style="float: left">Reporting</li>
+    <div rsf:id="navIntraTool:" class="navIntraTool"/>
+    <ul class="breadCrumb">
+        <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+        <li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+        <li rsf:id="page-title" class="lastCrumbNoFloat">Reporting</li>
     </ul>
     
     <div rsf:id="message-for:*" class="alertMessage">
-      <ul style="margin:0px;">
+      <ul>
         <li>Message for user here</li>
       </ul>
     </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate_search.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate_search.html
@@ -37,18 +37,18 @@
         <div class="portletBody">
             <div rsf:id="navIntraTool:" class="navIntraTool"/>
             <ul class="breadCrumb">
-                <li style="float: left">
+                <li>
                     <a rsf:id="summary-link" href="summary.html">Summary</a>
                 </li>
-				<li style="float: left">
+				<li>
 					<a rsf:id="administrate-link" href="administrate.html">Administrate</a>
 				</li>
-                <li class="lastCrumb">
+                <li class="lastCrumbNoFloat">
                     <span rsf:id="msg=administrate.search.breadcrumb.title">Search</span>
                 </li>
             </ul>
             <div rsf:id="message-for:*" class="alertMessage">
-                <ul style="margin:0px;">
+                <ul>
                     <li>
                         Message for user here
                     </li>
@@ -77,8 +77,7 @@
             </div>
             <!--note: form does not display if there is no results returned from the search-->
             <div rsf:id="searchResults:">
-				<table class="listHier lines nolines" border="0" cellpadding="0"
-					cellspacing="0" summary="placeholder summary">
+				<table class="evalsysTable">
 					<thead>
 						<tr>
 							<th id="item-title">

--- a/sakai-evaluation-tool/src/webapp/content/templates/administrate_search.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/administrate_search.html
@@ -54,7 +54,7 @@
                     </li>
                 </ul>
             </div>
-            <div rsf:id="msg=administrate.search.instruction" class="instruction">
+            <div rsf:id="msg=administrate.search.instruction" class="instructionText">
             </div>
             <div class="navPanel"> 
                 <div class="viewNav">
@@ -183,7 +183,7 @@
 				</table>
 			</div>
             <!--note: block displays if there is no results returned from the search-->
-            <div rsf:id="no-items:" class="instruction">
+            <div rsf:id="no-items:" class="instructionText">
                 <span rsf:id="msg=administrate.search.list.empty.note">No items found</span>
             </div>
         </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/choose_existing_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/choose_existing_items.html
@@ -55,7 +55,7 @@
 		</div>	
 		<div class="searchNav">
 				<span rsf:id="search-current" class="highlight">Current Search:</span>
-				<span rsf:id="search-current-value" class="instruction">Search Text</span>
+				<span rsf:id="search-current-value" class="instructionText">Search Text</span>
 				<form rsf:id="search-form" action="choose_existing_items.html" method="get">
 					<input rsf:id="search-box" type="text" size="25" maxlength="100" />
 					<input rsf:id="search-command" type="submit" value="Search" />
@@ -89,7 +89,7 @@
 							<span rsf:id="item-text">Item Text (the text entered for the item itself will appear here, it is possibly quite long</span>
 						</label>
 						</h5>
-						<div rsf:id="item-scale" class="instruction">Item Scale (the title of the scale and the points in parens)</div>
+						<div rsf:id="item-scale" class="instructionText">Item Scale (the title of the scale and the points in parens)</div>
 
 					</td>
 				</tr>
@@ -103,7 +103,7 @@
 								<span rsf:id="item-text">Item Text (the text entered for the item itself will appear here, it is possibly quite long</span>
 							</label>
 						</h5>
-						<div rsf:id="item-scale" class="instruction">Item Scale (the title of the scale and the points in parens)</div>
+						<div rsf:id="item-scale" class="instructionText">Item Scale (the title of the scale and the points in parens)</div>
 					</td>
 				</tr>
 			</tbody>

--- a/sakai-evaluation-tool/src/webapp/content/templates/choose_existing_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/choose_existing_items.html
@@ -39,12 +39,12 @@
 			<li><a rsf:id="modify-template-link" href="template_modify.html">Template</a></li>
 			<!--// gsilver: this link goes to the dashboard -->
 			<li><a rsf:id="modify-items-link" href="modify_items.html">Items</a></li>
-			<li rsf:id="msg=items.choose.items" class="lastCrumb">Choose Items</li>
+			<li rsf:id="msg=items.choose.items" class="lastCrumbNoFloat">Choose Items</li>
 		</ul>
 	</div>
 	
 	<div rsf:id="message-for:*" class="alertMessage">
-		<ul style="margin:0px;">
+		<ul>
 			<li>Message for user here</li>
 		</ul>
 	</div>
@@ -71,7 +71,7 @@
             <a rsf:id="cancel-items" href="template_modify.html" class="makeButton" id="cancel-items" style="display:inline;float:none" accesskey="x">Cancel</a>
         </p>
 
-		<table class="listHier lines nolines" summary="Column 1 has checkboxes used to select items, Column 2 has information about items" cellpadding="0" cellspacing="0">
+		<table class="evalsysTable" summary="Column 1 has checkboxes used to select items, Column 2 has information about items">
 			<caption rsf:id="msg=item.list.summary" class="skip">Selectable items. Column 1 has checkboxes used to select items, Column 2 has information about items</caption>
 			<thead class="skip">
 				<tr>

--- a/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_category.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_category.html
@@ -25,7 +25,7 @@
 <body>
 	<div class="portletBody">		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
@@ -47,7 +47,7 @@
 
 		<p rsf:id="category-instructions" class="instructionText">Click on a category to see objectives within it</p>
 		
-		<table  summary="Column 1 has links to categories, Column 2 has descriptions of categories" cellpadding="0" cellspacing="0"  class="listHier lines nolines" style="width:100%">
+		<table  summary="Column 1 has links to categories, Column 2 has descriptions of categories" class="evalsysTable" style="width:100%">
 			<caption rsf:id="category-list-summary" class="skip">Column 1 has links to categories, Column 2 has descriptions of categories</caption>	
 			<thead>
 				<tr>

--- a/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_category.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_category.html
@@ -45,7 +45,7 @@
 			</div>	
 		</div>
 
-		<p rsf:id="category-instructions" class="instruction">Click on a category to see objectives within it</p>
+		<p rsf:id="category-instructions" class="instructionText">Click on a category to see objectives within it</p>
 		
 		<table  summary="Column 1 has links to categories, Column 2 has descriptions of categories" cellpadding="0" cellspacing="0"  class="listHier lines nolines" style="width:100%">
 			<caption rsf:id="category-list-summary" class="skip">Column 1 has links to categories, Column 2 has descriptions of categories</caption>	

--- a/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_items.html
@@ -72,7 +72,7 @@
 		<span rsf:id="objective"  class="highlight">Objective</span> :
 		<span rsf:id="objective-current">Current Objective</span>
 	</h4>
-	<p class="instruction">
+	<p class="instructionText">
 		<span rsf:id="items" >Items</span> :
 		<span rsf:id="items-instructions">Check the items you want to use in your template and click the Insert button at the bottom</span>
 	</p>	
@@ -107,7 +107,7 @@
 					<label rsf:id="item-label" for="id1">
 						<span rsf:id="item-text">Item Text (the text entered for the item itself will appear here, it is possibly quite long</span>
 					</label>
-					<div class="instruction">
+					<div class="instructionText">
 						<span rsf:id="item-scale">Item Scale (the title of the scale and the points in parens)</span>
 						<span rsf:id="item-expert-desc">Expert description (the description of what this item is good for assessing and where it should be used</span>
 					</div>	
@@ -121,7 +121,7 @@
 					<label rsf:id="item-label" for="id2">
 						<span rsf:id="item-text">Item Text (the text entered for the item itself will appear here, it is possibly quite long</span>
 					</label>
-					<div class="instruction">
+					<div class="instructionText">
 						<span rsf:id="item-scale" class="itemsScale">Item Scale (the title of the scale and the points in parens)</span>
 						<span rsf:id="item-expert-desc" class="itemsDesc">Expert description (the description of what this item is good for assessing and where it should be used</span>
 					</div>	

--- a/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_items.html
@@ -41,7 +41,7 @@
      <h2 rsf:id="expert-items" class="titleHeader">Expert Items:</h2>
 	
 	<div rsf:id="message-for:*" class="alertMessage">
-		<ul style="margin:0px;">
+		<ul>
 			<li>Message for user here</li>
 		</ul>
 	</div>
@@ -88,7 +88,7 @@
     </p>    
   
 		
-	<table  summary="Column 1 has checkboxes used to select items, Column 2 has information about items" cellpadding="0" cellspacing="0" class="listHier lines nolines" style="width:auto;min-width:50%">
+	<table  summary="Column 1 has checkboxes used to select items, Column 2 has information about items" class="evalsysTable" style="width:auto;min-width:50%">
 		<caption rsf:id="expert-items-summary" class="skip">Column 1 has checkboxes used to select items, Column 2 has information about items</caption>
 		<thead>
 			<tr rsf:id="expert-item-header-row:">

--- a/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_objective.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_objective.html
@@ -52,7 +52,7 @@
    <h2 rsf:id="expert-items" class="titleHeader">Expert Items:</h2>
 
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
@@ -89,7 +89,7 @@
 		<!-- //gsilver: need to come up with a min-width for this table -->
 		<!-- //gsilver:if this list has no items - omit, as it will not validate -->
 
-		<table summary="Column 1 has links to objectives, Column 2 has descriptions of objectives" cellpadding="0" cellspacing="0" class="listHier lines nolines" style="width:100%">
+		<table summary="Column 1 has links to objectives, Column 2 has descriptions of objectives" class="evalsysTable" style="width:100%">
 			<caption rsf:id="objective-list-summary" class="skip">Column 1 has links used to select objectives, Column 2 has information about these objectives</caption>
 			<thead>
 				<tr>
@@ -136,7 +136,7 @@
 				<!-- //gsilver: need to come up with a min-width for this table -->
 				<!-- //gsilver:if this list has no items - omit, as it will not validate -->
 
-				<table summary="Column 1 has checkboxes used to select items, Column 2 has information about items" cellpadding="0" cellspacing="0" class="listHier lines nolines" style="width:100%;">
+				<table summary="Column 1 has checkboxes used to select items, Column 2 has information about items" class="evalsysTable" style="width:100%;">
 					<caption rsf:id="item-list-summary" class="skip">Column 1 has checkboxes used to select items, Column 2 has information about items</caption>
 					<thead>
 						<tr rsf:id="expert-item-header-row:">

--- a/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_objective.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/choose_expert_objective.html
@@ -79,10 +79,10 @@
 			<span rsf:id="category-current" class="highlight">Current Category</span>
 		</h3>
 
-		<div class="instruction">
+		<div class="instructionText">
 			<div rsf:id="objective-header:">
 				<span rsf:id="objective"  >Objective</span> :
-				<span rsf:id="objective-instructions" class="instruction" >Click on an objective to select items related to it</span>
+				<span rsf:id="objective-instructions" class="instructionText" >Click on an objective to select items related to it</span>
 			</div>
 		</div>
 
@@ -114,7 +114,7 @@
 					</td>
 					<td>
 						<span rsf:id="objective-description">This is the objective description for the expert objective which I expect will be quite long and involved and will explain to the user what items are in this objective and what it is good for</span>
-						<span rsf:id="objective-no-description" class="instruction"></span>
+						<span rsf:id="objective-no-description" class="instructionText"></span>
 					</td>
 				</tr>
 			</tbody>
@@ -128,7 +128,7 @@
 
 		<div rsf:id="form-branch:">
 			<form rsf:id="insert-items-form" id="insert-items-form" method="post" action="template_modify.html" style="margin:0px;">
-				<p class="instruction">
+				<p class="instructionText">
 					<span rsf:id="items">Items</span> :
 					<span rsf:id="items-instructions">Check the items you want to use in your template and click the Insert button at the bottom</span>
 				</p>
@@ -157,9 +157,9 @@
 										<span rsf:id="item-text">Item Text (the text entered for the item itself will appear here, it is possibly quite long</span>
 									</label>
 								</h5>
-								<div class="instruction">
-									<span rsf:id="item-scale"  class="instruction">Item Scale (the title of the scale and the points in parens)</span>
-									<span rsf:id="item-expert-desc"class="instruction">Expert description (the description of what this item is good for assessing and where it should be used</span>
+								<div class="instructionText">
+									<span rsf:id="item-scale"  class="instructionText">Item Scale (the title of the scale and the points in parens)</span>
+									<span rsf:id="item-expert-desc"class="instructionText">Expert description (the description of what this item is good for assessing and where it should be used</span>
 								</div>
 
 							</td>

--- a/sakai-evaluation-tool/src/webapp/content/templates/chown_template.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/chown_template.html
@@ -31,18 +31,20 @@
 		   <div rsf:id="navIntraTool:" class="navIntraTool"/>
 		
 			<ul class="breadCrumb">
-				<li><a rsf:id="summary-link" href="summary.html">Summary</a></li><li><a rsf:id="control-templates-link" href="control_templates.html">My Templates</a></li><li class="lastCrumb" rsf:id="chown-template-title">Change Template Owner</li>
+				<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+				<li><a rsf:id="control-templates-link" href="control_templates.html">My Templates</a></li>
+				<li class="lastCrumbNoFloat" rsf:id="chown-template-title">Change Template Owner</li>
 			</ul>
 			
 			<div rsf:id="message-for:*" class="alertMessage">
-				<ul style="margin:0px;">
-					<li>Message for user here</li>                                                    
+				<ul>
+					<li>Message for user here</li>
 				</ul>
 			</div>
 			
 			<h3 rsf:id="chown-template-title"></h3>
 			<div rsf:id="cannot-chown-message" class="alertMessage"></div>
-																																													  
+
 			<div rsf:id="chownDiv:">
 				<div class="alertMessage">
 					<span rsf:id="chown-template-confirm-text">Are you sure you want to remove template NAME? The removal is permanant.</span>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_email_templates.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_email_templates.html
@@ -55,7 +55,7 @@
             &nbsp;
         </div>
 
-		<p class="instruction" rsf:id="msg=controlemailtemplates.instructions">A blurb here about this list, underscoring default templates</p>
+		<p class="instructionText" rsf:id="msg=controlemailtemplates.instructions">A blurb here about this list, underscoring default templates</p>
 		<ol class="scaleOuterList">
 			<li rsf:id="templatesList:" class="scaleOuterListLi">
 				<div class="scaleTitleLine">

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_email_templates.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_email_templates.html
@@ -33,14 +33,14 @@
 
        <div rsf:id="navIntraTool:" class="navIntraTool"/>
 
-		<ul class="breadCrumb"  style="clear:both;height:1.5em">
-			<li  style="float:left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-			<li  style="float:left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-			<li rsf:id="msg=controlemailtemplates.page.title" class="lastCrumb"  style="float:left">Email Templates</li>
+		<ul class="breadCrumb">
+			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+			<li rsf:id="msg=controlemailtemplates.page.title" class="lastCrumbNoFloat">Email Templates</li>
 		</ul>
 
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_eval_admin.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_eval_admin.html
@@ -37,23 +37,23 @@
 		
 		<div rsf:id="navIntraTool:" class="navIntraTool"/>
 
-		<ul class="breadCrumb" style="clear: both; height: 1.5em">
-			<li style="float: left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-			<li style="float: left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-			<li rsf:id="msg=controlevaladmin.page.title" class="lastCrumb" style="float: left">Control Eval Admin</li>
+		<ul class="breadCrumb">
+			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+			<li rsf:id="msg=controlevaladmin.page.title" class="lastCrumbNoFloat">Control Eval Admin</li>
 		</ul>
 
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
 
 		<p class="instructionText" rsf:id="control-eval-admin-note">Note about how users cannot remove their own admin rights</p>
 		
-		<form rsf:id="eval-admin-form" style="display: inline-block;">
+		<form rsf:id="eval-admin-form" class="inlineBlockForm">
 			
-			<table id="evalAdmin-table">
+			<table class="evalsysTable">
 				
 				<thead>
 					<tr>
@@ -65,7 +65,7 @@
 				
 				<tbody>
 
-					<tr id="assign-fields" class="userPermsRow">
+					<tr id="assign-fields">
 						
 						<td class="assignEvalAdmin" colspan="2">
 							<label for="user-eid-input" rsf:id="user-eid-label">Assign New Eval Admin: </label>
@@ -76,7 +76,7 @@
 						
 					</tr>
 					
-					<tr rsf:id="eval-admin:" class="userPermsRow">
+					<tr rsf:id="eval-admin:">
 						<td rsf:id="user-info">[display-name] ([user-eid])</td>
 						<td rsf:id="assignor-info">Assigned by [assignor-user-eid] on [assign-date]</td>
 						<td><input type="submit" rsf:id="unassign-button" class="unassignButton" value="Unassign" /></td>
@@ -86,7 +86,7 @@
 				
 			</table>
 			
-			<table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+			<table class="evalsysTable">
 				
 				<thead>
 					<tr>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_eval_admin.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_eval_admin.html
@@ -63,7 +63,7 @@
 			</ul>
 		</div>
 		
-		<p class="instruction" rsf:id="control-eval-admin-note">Note about how users cannot remove their own admin rights</p>
+		<p class="instructionText" rsf:id="control-eval-admin-note">Note about how users cannot remove their own admin rights</p>
 		
 		<form rsf:id="eval-admin-form">
 			

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_eval_admin.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_eval_admin.html
@@ -35,39 +35,25 @@
 <body>
 	<div class="portletBody">
 		
-		<div class="navIntraTool">
-			<a rsf:id="administrate-link" href="administrate.html" class="inactive">Administrate</a>
-			<a rsf:id="summary-link" href="summary.html">Summary</a>
-			<a rsf:id="control-evaluations-link" href="control_evaluations.html">My Evaluations</a>
-			<a rsf:id="control-templates-link" href="control_templates.html">My Templates</a>
-			<a rsf:id="control-items-link" href="control_items.html">My Items</a>
-			<a rsf:id="control-scales-link" href="control_scales.html">My Scales</a>
-			<a rsf:id="control-emailtemplates-link" href="control_email_templates.html">My Email Templates</a>
-		</div>
-		
+		<div rsf:id="navIntraTool:" class="navIntraTool"/>
+
 		<ul class="breadCrumb" style="clear: both; height: 1.5em">
-			<li style="float: left">
-				<a rsf:id="summary-link" href="summary.html">Summary</a>
-			</li>
-			<li style="float: left">
-				<a rsf:id="administrate-link" href="administrate.html">Administrate</a>
-			</li>
-			<li rsf:id="control-eval-admin-title" class="lastCrumb" style="float: left">
-				Control Eval Admin
-			</li>
+			<li style="float: left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li style="float: left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+			<li rsf:id="msg=controlevaladmin.page.title" class="lastCrumb" style="float: left">Control Eval Admin</li>
 		</ul>
-		
+
 		<div rsf:id="message-for:*" class="alertMessage">
 			<ul style="margin:0px;">
 				<li>Message for user here</li>
 			</ul>
 		</div>
-		
+
 		<p class="instructionText" rsf:id="control-eval-admin-note">Note about how users cannot remove their own admin rights</p>
 		
-		<form rsf:id="eval-admin-form">
+		<form rsf:id="eval-admin-form" style="display: inline-block;">
 			
-			<table class="evalAdminTable">
+			<table id="evalAdmin-table">
 				
 				<thead>
 					<tr>
@@ -78,18 +64,8 @@
 				</thead>
 				
 				<tbody>
-					
-					<tr rsf:id="eval-admin:">
-						<td rsf:id="user-info">[display-name] ([user-eid])</td>
-						<td rsf:id="assignor-info">Assigned by [assignor-user-eid] on [assign-date]</td>
-						<td><input type="submit" rsf:id="unassign-button" class="unassignButton" value="Unassign" /></td>
-					</tr>
-					
-				</tbody>
-				
-				<tfoot>
-					
-					<tr id="assign-fields">
+
+					<tr id="assign-fields" class="userPermsRow">
 						
 						<td class="assignEvalAdmin" colspan="2">
 							<label for="user-eid-input" rsf:id="user-eid-label">Assign New Eval Admin: </label>
@@ -100,11 +76,17 @@
 						
 					</tr>
 					
-				</tfoot>
+					<tr rsf:id="eval-admin:" class="userPermsRow">
+						<td rsf:id="user-info">[display-name] ([user-eid])</td>
+						<td rsf:id="assignor-info">Assigned by [assignor-user-eid] on [assign-date]</td>
+						<td><input type="submit" rsf:id="unassign-button" class="unassignButton" value="Unassign" /></td>
+					</tr>
+					
+				</tbody>
 				
 			</table>
 			
-			<table class="evalAdminTable">
+			<table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
 				
 				<thead>
 					<tr>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_evaluations.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_evaluations.html
@@ -49,13 +49,13 @@
             </ul>
         </div>
 
-        <p class="elementAlertFront instruction" rsf:id="eval-instructions-group-notpublished">
+        <p class="elementAlertFront instructionText" rsf:id="eval-instructions-group-notpublished">
             This evaluation is assigned to at least one currently unpublished site. Publish these sites for students to be notified via email and given access to complete this evaluation.
         </p>
 
         <div rsf:id="partial-eval-listing:">
             <h3 rsf:id="msg=controlevaluations.partial.header">Partial Evaluations</h3>
-            <p class="instruction">
+            <p class="instructionText">
                 <span rsf:id="msg=controlevaluations.partial.description">Your Evaluations which you started creating but did not complete</span>
                 <span rsf:id="partial-cleanup-note"></span>
             </p>
@@ -91,7 +91,7 @@
         </div>
 
         <h3 rsf:id="msg=controlevaluations.inqueue.header">In-Queue Evaluations</h3>
-        <p rsf:id="msg=controlevaluations.inqueue.description" class="instruction">
+        <p rsf:id="msg=controlevaluations.inqueue.description" class="instructionText">
             Your Evaluations in queue that have not started yet
         </p>
         <div rsf:id="inqueue-eval-listing:">
@@ -141,12 +141,12 @@
                 </tbody>
             </table>
         </div>
-        <p rsf:id="no-inqueue-evals" class="instruction highlightPanel">
+        <p rsf:id="no-inqueue-evals" class="instructionText highlightPanel">
             No evaluations in-queue
         </p>
 
         <h3 rsf:id="msg=controlevaluations.active.header" style="font-weight:bold;">Active Evaluations</h3>
-        <p rsf:id="msg=controlevaluations.active.description" class="instruction">
+        <p rsf:id="msg=controlevaluations.active.description" class="instructionText">
             Your Evaluations currently active for users to take
         </p>
         <div rsf:id="active-eval-listing:">
@@ -214,12 +214,12 @@
                 </tbody>
             </table>
         </div>
-        <p rsf:id="no-active-evals" class="instruction highlightPanel">
+        <p rsf:id="no-active-evals" class="instructionText highlightPanel">
             No active evaluations
         </p>
 
         <h3 rsf:id="msg=controlevaluations.closed.header">Closed Evaluations</h3>
-        <p rsf:id="msg=controlevaluations.closed.description" class="instruction">
+        <p rsf:id="msg=controlevaluations.closed.description" class="instructionText">
             Your Evaluations which have been completed
         </p>
         <div rsf:id="closed-eval-listing:">
@@ -286,7 +286,7 @@
             </table>
             <br/>
         </div>
-        <p rsf:id="no-closed-evals" class="instruction highlightPanel">
+        <p rsf:id="no-closed-evals" class="instructionText highlightPanel">
             No closed evaluations
         </p>
         <hr />

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_evaluations.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_evaluations.html
@@ -14,7 +14,7 @@
     permissions and limitations under the License.
 
 -->
-<!DOCTYPE html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns:rsf="http://ponder.org.uk/rsf" xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title rsf:id="page-title">My Evaluations</title>
@@ -30,19 +30,19 @@
 <body>
     <div class="portletBody">
         <div rsf:id="navIntraTool:" class="navIntraTool"/>
-        <ul class="breadCrumb" style="clear:both;height:1.5em">
-            <li style="float:left">
+        <ul class="breadCrumb">
+            <li>
                 <a rsf:id="summary-link" href="summary.html">Summary</a>
             </li>
-            <li style="float:left" rsf:id="page-title" class="lastCrumb">
+            <li rsf:id="page-title" class="lastCrumbNoFloat">
                 My Evaluations
             </li>
-            <li style="float:right" class="lastCrumb">
+            <li class="lastCrumb">
                 <a rsf:id="begin-evaluation-link" href="evaluation_create.html" class="addItem">Start Evaluation</a>
             </li>
         </ul>
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
                 <li>
                     Message for user here
                 </li>
@@ -59,7 +59,7 @@
                 <span rsf:id="msg=controlevaluations.partial.description">Your Evaluations which you started creating but did not complete</span>
                 <span rsf:id="partial-cleanup-note"></span>
             </p>
-            <table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+            <table class="evalsysTable">
                 <thead>
                     <tr>
                         <th rsf:id="msg=controlevaluations.eval.title.header" width="20%">
@@ -95,7 +95,7 @@
             Your Evaluations in queue that have not started yet
         </p>
         <div rsf:id="inqueue-eval-listing:">
-            <table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+            <table class="evalsysTable">
                 <thead>
                     <tr>
                         <th rsf:id="msg=controlevaluations.eval.title.header" width="20%">
@@ -150,7 +150,7 @@
             Your Evaluations currently active for users to take
         </p>
         <div rsf:id="active-eval-listing:">
-            <table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+            <table class="evalsysTable">
                 <thead>
                     <tr>
                         <th rsf:id="msg=controlevaluations.eval.title.header" width="20%">
@@ -223,7 +223,7 @@
             Your Evaluations which have been completed
         </p>
         <div rsf:id="closed-eval-listing:">
-            <table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+            <table class="evalsysTable">
                 <thead>
                     <tr>
                         <th rsf:id="msg=controlevaluations.eval.title.header" width="20%">

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_expert_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_expert_items.html
@@ -54,11 +54,11 @@
 
 		<ul class="breadCrumb">
 			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-			<li rsf:id="page-title"  class="lastCrumb">Expert Items</li>
+			<li rsf:id="page-title" class="lastCrumbNoFloat">Expert Items</li>
 		</ul>
 		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
@@ -83,7 +83,7 @@
 					
 		<!-- This block (list items) is not visible if there are no items visible -->
         <form rsf:id="expertForm">
-  			<table rsf:id="expertitem-listing:" class="listHier lines nolines" border="0" cellpadding="0" cellspacing="0" summary="placeholder summary">
+  			<table class="evalsysTable">
   				<thead>
   					<tr>
   					<th id="itemMD">

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_expert_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_expert_items.html
@@ -83,7 +83,7 @@
 					
 		<!-- This block (list items) is not visible if there are no items visible -->
         <form rsf:id="expertForm">
-  			<table class="evalsysTable">
+  			<table rsf:id="expertitem-listing:" class="evalsysTable">
   				<thead>
   					<tr>
   					<th id="itemMD">

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_expert_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_expert_items.html
@@ -66,7 +66,7 @@
 		<div class="navPanel">
 				<div class="viewNav">
 					<h3><span rsf:id="items-header">Items</span></h3>
-					<p rsf:id="items-description" class="instruction">Questions or statements which the evaluator responds to.</p>
+					<p rsf:id="items-description" class="instructionText">Questions or statements which the evaluator responds to.</p>
 				</div>
 				<div class="listNav">
 					<!-- label rsf:id="add-item-header" for="item-classification-list-selection">Add Item</label -->
@@ -162,7 +162,7 @@
   			</table>
         </form>
 		
-		<div rsf:id="no-items" class="instruction">No items available</div>
+		<div rsf:id="no-items" class="instructionText">No items available</div>
 	
 	</div>
 </body>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_hierarchy.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_hierarchy.html
@@ -43,7 +43,7 @@
     <a rsf:id="show-hide-groups" href="">Show/Hide Groups</a> <a rsf:id="show-hide-users" href="">Show/Hide Users</a>
     <div rsf:id="hierarchy-tree:">
         <!-- Everything in here is replaced by the html in /evaluation/tool/src/webapp/component-templates/hierarchy_controls.html -->
-        <table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+        <table id="hierarchy-table">
             <thead>
                 <tr>
                     <th rsf:id="hierarchy-header">Hierarchy Level</th>
@@ -52,7 +52,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr rsf:id="hierarchy-level-row:">
+                <tr rsf:id="hierarchy-level-row:" class="userPermsRow">
                     <td rsf:id="node-name" style="text-indent:0em"> - Institution Level</td>
                     <td>
                         <span rsf:id="number-children">3</span>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_hierarchy.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_hierarchy.html
@@ -33,17 +33,17 @@
 
      <div rsf:id="navIntraTool:" class="navIntraTool"/>
 
-    <ul class="breadCrumb" style="clear: both; height: 1.5em">
-        <li style="float: left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-        <li style="float: left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-        <li rsf:id="msg=controlhierarchy.page.title" class="lastCrumb" style="float: left">Hierarchy</li>
+    <ul class="breadCrumb">
+        <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+        <li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+        <li rsf:id="msg=controlhierarchy.page.title" class="lastCrumbNoFloat">Hierarchy</li>
     </ul>
 
     <h3 rsf:id="msg=controlhierarchy.table.hierarchy.header">Control Hierarchy</h3> 
     <a rsf:id="show-hide-groups" href="">Show/Hide Groups</a> <a rsf:id="show-hide-users" href="">Show/Hide Users</a>
     <div rsf:id="hierarchy-tree:">
         <!-- Everything in here is replaced by the html in /evaluation/tool/src/webapp/component-templates/hierarchy_controls.html -->
-        <table id="hierarchy-table">
+        <table class="evalsysTable">
             <thead>
                 <tr>
                     <th rsf:id="hierarchy-header">Hierarchy Level</th>
@@ -52,12 +52,12 @@
                 </tr>
             </thead>
             <tbody>
-                <tr rsf:id="hierarchy-level-row:" class="userPermsRow">
-                    <td rsf:id="node-name" style="text-indent:0em"> - Institution Level</td>
+                <tr rsf:id="hierarchy-level-row:">
+                    <td rsf:id="node-name" class="noTextIndent"> - Institution Level</td>
                     <td>
                         <span rsf:id="number-children">3</span>
-                        <a rsf:id="add-child-link" style="font-size:0.9em;" href="">Add</a>
-                        <a rsf:id="modify-node-link" style="font-size:0.9em;" href="">Modify</a>
+                        <a rsf:id="add-child-link" class="inlineLink" href="">Add</a>
+                        <a rsf:id="modify-node-link" class="inlineLink" href="">Modify</a>
                         <form rsf:id="remove-node-form">
                             <input type="submit" rsf:id="remove-node-button" value="Remove"/>
                         </form>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_items.html
@@ -55,12 +55,12 @@
 
 		<ul class="breadCrumb">
 			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-			<li rsf:id="page-title"  class="lastCrumb">My Items</li>
-			<li style="float:right" class="lastCrumb"><a rsf:id="expert-items-link" href="control_expert_items.html"  class="addItem">Expert Items</a></li>
+			<li rsf:id="page-title" class="lastCrumbNoFloat">My Items</li>
+			<li class="lastCrumb"><a rsf:id="expert-items-link" href="control_expert_items.html"  class="addItem">Expert Items</a></li>
 		</ul>
 					
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
@@ -104,7 +104,7 @@
 		
 		<!-- This block (list items) is not visible if there are no items visible -->
         <form rsf:id="copyForm">
-  			<table rsf:id="item-listing:" class="listHier lines nolines" border="0" cellpadding="0" cellspacing="0" summary="placeholder summary">
+  			<table rsf:id="item-listing:" class="evalsysTable">
   				<thead class="skip" style="display:none">
   					<tr>
   						<th id="itemMD">

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_items.html
@@ -68,7 +68,7 @@
 		<div class="navPanel">
 				<div class="viewNav">
 					<h3><span rsf:id="items-header">Items</span></h3>
-					<p rsf:id="items-description" class="instruction">Questions or statements which the evaluator responds to.</p>
+					<p rsf:id="items-description" class="instructionText">Questions or statements which the evaluator responds to.</p>
 				</div>
 				<div class="listNav">
 					<label rsf:id="add-item-header" for="item-classification-list-selection">Add Item</label>
@@ -122,7 +122,7 @@
   					<tr rsf:id="item-row:">
   						<td headers="itemMD">
   							<h4 rsf:id="item-classification" style="display:inline">Item Classification</h4>
-  							<span rsf:id="item-scale" class="instruction">
+  							<span rsf:id="item-scale" class="instructionText">
   								- Item Scale (the title of the scale and the points in parens)
   							</span>
                             <span rsf:id="item-expert" style="font-weight: bold;">
@@ -168,7 +168,7 @@
   			</table>
         </form>
 		
-		<div rsf:id="no-items" class="instruction">No items available</div>
+		<div rsf:id="no-items" class="instructionText">No items available</div>
 	
 	</div>
 </body>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_scales.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_scales.html
@@ -55,7 +55,7 @@
 			<span rsf:id="scales-control-heading">Scales Control</span>
 		</h3>	
 		<!--// gsilver: need to know how to add simple messages -->
-		<p class="instruction" rsf:id="scales-control-instruction">A blurb here about this list, underscoring "scales in system" and "scales you own" differences</p>
+		<p class="instructionText" rsf:id="scales-control-instruction">A blurb here about this list, underscoring "scales in system" and "scales you own" differences</p>
 
         <form rsf:id="copyForm">
   			<ol class="scaleOuterList">

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_scales.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_scales.html
@@ -14,7 +14,7 @@
     permissions and limitations under the License.
 
 -->
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns:rsf="http://ponder.org.uk/rsf" xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title rsf:id="page-title">Scale Control</title>
@@ -40,14 +40,14 @@
 
         <div rsf:id="navIntraTool:" class="navIntraTool"></div>
 
-		<ul class="breadCrumb"  style="clear:both;height:1.5em">
-			<li style="float:left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-			<li style="float:left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-			<li rsf:id="page-title" class="lastCrumb"  style="float:left">Scales</li>
-			<li style="float:right" class="lastCrumb"><a rsf:id="add-new-scale-link" href="scale_modify.html" class="addItem">Add new scale</a></li>
+		<ul class="breadCrumb">
+			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+			<li rsf:id="page-title" class="lastCrumbNoFloat">Scales</li>
+			<li class="lastCrumb"><a rsf:id="add-new-scale-link" href="scale_modify.html" class="addItem">Add new scale</a></li>
 		</ul>
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_templates.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_templates.html
@@ -46,7 +46,7 @@
 		</div>
 
 		<h3 rsf:id="templates-header" style="font-weight:bold;" class="templatesControl">Evaluation Templates</h3>
-		<p class="instruction"  rsf:id="templates-description">Templates store items in a layout and are used to create evaluations</p>
+		<p class="instructionText"  rsf:id="templates-description">Templates store items in a layout and are used to create evaluations</p>
 		
 		<!-- This block (list template) is not visible if there are no templates visible -->
 		<div rsf:id="template-listing:">
@@ -85,7 +85,7 @@
               </table>
             </form>
 		</div>
-		<p rsf:id="no-templates" class="instruction">No templates available</p>
+		<p rsf:id="no-templates" class="instructionText">No templates available</p>
 	
 	</div>
 </body>

--- a/sakai-evaluation-tool/src/webapp/content/templates/control_templates.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/control_templates.html
@@ -14,7 +14,7 @@
     permissions and limitations under the License.
 
 -->
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns:rsf="http://ponder.org.uk/rsf" xmlns="http://www.w3.org/1999/xhtml">
 <head>
    <title rsf:id="page-title">My Templates</title>
@@ -33,14 +33,15 @@
 
        <div rsf:id="navIntraTool:" class="navIntraTool"></div>
 
-		<ul class="breadCrumb"  style="clear:both;height:1.5em">
-			<li  style="float:left"><a rsf:id="summary-link" href="summary.html">Summary</a></li><li class="lastCrumb"  style="float:left" rsf:id="page-title">My Templates</li>
-			<li style="float:right" class="lastCrumb"><a rsf:id="create-template-link" href="template_title_desc.html" class="addItem">Add Template</a></li>
-			<li style="float:right" class="lastCrumb"><a rsf:id="create-evaluation-link" href="evaluation_start.html"  class="addItem">Start Evaluation</a></li>
+		<ul class="breadCrumb">
+			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li class="lastCrumbNoFloat" rsf:id="page-title">My Templates</li>
+			<li class="lastCrumb"><a rsf:id="create-template-link" href="template_title_desc.html" class="addItem">Add Template</a></li>
+			<li class="lastCrumb"><a rsf:id="create-evaluation-link" href="evaluation_start.html"  class="addItem">Start Evaluation</a></li>
 		</ul>
 		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
@@ -51,7 +52,7 @@
 		<!-- This block (list template) is not visible if there are no templates visible -->
 		<div rsf:id="template-listing:">
             <form rsf:id="copyForm">
-              <table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+              <table class="evalsysTable">
                  <thead>
                     <tr>
                        <!-- rsf cannot computer ids when using msg= so had to remove the ids -->

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign.html
@@ -41,16 +41,19 @@
 <body>
 	<div class="portletBody">
 		
-		<div rsf:id="navIntraTool:" class="navIntraTool"/>			
+		<div rsf:id="navIntraTool:" class="navIntraTool"/>
         <div>
             <ul class="breadCrumb">
             <!-- first link in the bcrumb does not seem to be looking in the message.properties for a value -->
-            <li><a rsf:id="summary-link" href="summary.html">Evaluations dashboard</a></li><li rsf:id="eval-start-text">Add Evaluation</li><li><a rsf:id="eval-settings-link" href="evaluation_settings.html">Evaluation Settings</a></li><li class="lastCrumb" rsf:id="msg=assigneval.page.title">Assign Evaluation</li>                 
+            <li><a rsf:id="summary-link" href="summary.html">Evaluations dashboard</a></li>
+            <li rsf:id="eval-start-text">Add Evaluation</li>
+            <li><a rsf:id="eval-settings-link" href="evaluation_settings.html">Evaluation Settings</a></li>
+            <li class="lastCrumbNoFloat" rsf:id="msg=assigneval.page.title">Assign Evaluation</li>
             </ul>
         </div>
 		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
@@ -95,7 +98,7 @@
 					This denotes a site that are currently unpublished. Make sure you publish it otherwise students will not be notified via email or given access to complete this evaluation.</p>
 					
 					<div rsf:id="siteCheckboxes"/>
-					<table border="0" cellspacing="0" cellpadding="3" style="width:90%" class="listHier lines nolines" >
+					<table style="width:90%" class="evalsysTable" >
 						<thead>
 							<tr>
 								<th class="attach" >
@@ -141,7 +144,7 @@
 				</p>
 				<div rsf:id="adhocgroups-assignment-area" id="adhocgroups-assignment-area">
 					<a rsf:id="new-adhocgroup-link" href="#">Create a new Adhoc Group</a>
-					<table rsf:id="adhoc-groups-table" border="0" cellspacing="0" cellpadding="3" style="width:90%" class="listHier lines nolines" >
+					<table rsf:id="adhoc-groups-table" style="width:90%" class="evalsysTable" >
 						<thead>
 							<tr>
 								<th class="attach" >

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign.html
@@ -90,8 +90,8 @@
 					<span rsf:id="msg=assigneval.page.groups.title">Assign to Evaluation Groups</span>
 				</p>
 				<div rsf:id="evalgroups-assignment-area" id="evalgroups-assignment-area">
-					<p class="instruction"  rsf:id="assign-eval-instructions">You are allowed to assign this evaluation (eval title) to the groups listed below.</p> 
-					<p class="elementAlertFront instruction" rsf:id="assign-eval-instructions-group-notpublished">
+					<p class="instructionText"  rsf:id="assign-eval-instructions">You are allowed to assign this evaluation (eval title) to the groups listed below.</p> 
+					<p class="elementAlertFront instructionText" rsf:id="assign-eval-instructions-group-notpublished">
 					This denotes a site that are currently unpublished. Make sure you publish it otherwise students will not be notified via email or given access to complete this evaluation.</p>
 					
 					<div rsf:id="siteCheckboxes"/>
@@ -118,7 +118,7 @@
 									<label rsf:id="groupTitle" for="evalGroupId">group title</label>
 								</td>
 								<td>
-		                        	<span rsf:id="select-no" class="instruction">You cannot assign to this site, it has no member to take the evaluation.</span>
+		                        	<span rsf:id="select-no" class="instructionText">You cannot assign to this site, it has no member to take the evaluation.</span>
 		                        	<a rsf:id="select-instructors" href="#" title="Select Instructors"  rel="assignInstructorSelector">Select Instructors (5/5)</a>
 		                            <a rsf:id="select-tas" href="#" title="Select TAs" rel="assignTaSelector" style="margin-left:30px">Select TAs (5/12)</a>
 		                        </td>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign_confirm.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign_confirm.html
@@ -40,10 +40,10 @@
             </ul>
         </div>
         <h3 rsf:id="msg=assigneval.page.confirmation.title">Evaluation Assignment Confirmation</h3>
-        <p class="instruction" rsf:id="evalAssignInfo">
+        <p class="instructionText" rsf:id="evalAssignInfo">
             You have chosen to assign the evaluation (eval title) to the following groups.
         </p>
-        <p class="instruction" rsf:id="evalAssignInstructions">
+        <p class="instructionText" rsf:id="evalAssignInstructions">
             You may adjust the groups assigned to this evaluation up to the start date of the evaluation (25 May 2007).
         </p>
         <table class="itemSummary">
@@ -86,7 +86,7 @@
         <h4 rsf:id="msg=evaluationassignconfirm.courses.selected.header" style="font-weight:bold;">
             Individual Groups Selected:
         </h4>
-        <p rsf:id="noGroupsSelected" class="instruction indnt1">No groups selected</p>
+        <p rsf:id="noGroupsSelected" class="instructionText indnt1">No groups selected</p>
         <table rsf:id="showSelectedGroups:" border="0" cellspacing="0" cellpadding="0" style="width:70%" class="listHier lines nolines indnt1">
             <tr rsf:id="groups:">
                 <td width="60%">
@@ -102,7 +102,7 @@
             <h4 rsf:id="msg=evaluationassignconfirm.hiernodes.selected.header" style="font-weight:bold;">
                 Individual Hierarchy Nodes Selected:
             </h4>
-            <span rsf:id="noNodesSelected" class="instruction indnt1">No nodes selected</span>
+            <span rsf:id="noNodesSelected" class="instructionText indnt1">No nodes selected</span>
             <table rsf:id="showSelectedNodes:" border="0" cellspacing="0" cellpadding="0" style="width:70%" class="listHier lines nolines indnt1">
                 <tr rsf:id="nodes:">
                     <td width="60%">
@@ -119,7 +119,7 @@
             <h4 rsf:id="msg=evaluationassignconfirm.adhoc.selected.header" style="font-weight:bold;">
                 Adhoc Groups Selected:
             </h4>
-            <p rsf:id="noAdhocSelected" class="instruction indnt1">No groups selected</p>
+            <p rsf:id="noAdhocSelected" class="instructionText indnt1">No groups selected</p>
             <table rsf:id="showAdhocGroups:" border="0" cellspacing="0" cellpadding="0" style="width:70%" class="listHier lines nolines indnt1">
                 <tr rsf:id="groups:">
                     <td width="60%">

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign_confirm.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign_confirm.html
@@ -32,10 +32,14 @@
     <div class="portletBody">
         <div rsf:id="navIntraTool:" class="navIntraTool"/>
         <ul class="breadCrumb">
-			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li><li rsf:id="eval-start-text">Add Evaluation</li><li><a rsf:id="eval-settings-link" href="evaluation_settings.html">Evaluation Settings</a></li><li rsf:id="msg=assigneval.page.title">Assign Groups</li><li class="lastCrumb" rsf:id="msg=evaluationassignconfirm.page.title">Confirm Assignment</li>
+            <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+            <li rsf:id="eval-start-text">Add Evaluation</li>
+            <li><a rsf:id="eval-settings-link" href="evaluation_settings.html">Evaluation Settings</a></li>
+            <li rsf:id="msg=assigneval.page.title">Assign Groups</li>
+            <li class="lastCrumb" rsf:id="msg=evaluationassignconfirm.page.title">Confirm Assignment</li>
         </ul>
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
 				<li>Message for user here</li>
             </ul>
         </div>
@@ -87,7 +91,7 @@
             Individual Groups Selected:
         </h4>
         <p rsf:id="noGroupsSelected" class="instructionText indnt1">No groups selected</p>
-        <table rsf:id="showSelectedGroups:" border="0" cellspacing="0" cellpadding="0" style="width:70%" class="listHier lines nolines indnt1">
+        <table rsf:id="showSelectedGroups:" style="width:70%" class="evalsysTable indnt1">
             <tr rsf:id="groups:">
                 <td width="60%">
                     <span rsf:id="groupTitle">Group title</span> <span rsf:id="directGroupLink">(<a rsf:id="payload-component" href="take_eval.html" title="direct url to the evaluation for this group" target="_blank">link</a>)</span>
@@ -103,7 +107,7 @@
                 Individual Hierarchy Nodes Selected:
             </h4>
             <span rsf:id="noNodesSelected" class="instructionText indnt1">No nodes selected</span>
-            <table rsf:id="showSelectedNodes:" border="0" cellspacing="0" cellpadding="0" style="width:70%" class="listHier lines nolines indnt1">
+            <table rsf:id="showSelectedNodes:" style="width:70%" class="evalsysTable indnt1">
                 <tr rsf:id="nodes:">
                     <td width="60%">
                         <span rsf:id="nodeTitle">Department of Biology</span>
@@ -120,7 +124,7 @@
                 Adhoc Groups Selected:
             </h4>
             <p rsf:id="noAdhocSelected" class="instructionText indnt1">No groups selected</p>
-            <table rsf:id="showAdhocGroups:" border="0" cellspacing="0" cellpadding="0" style="width:70%" class="listHier lines nolines indnt1">
+            <table rsf:id="showAdhocGroups:" style="width:70%" class="evalsysTable indnt1">
                 <tr rsf:id="groups:">
                     <td width="60%">
                         <span rsf:id="groupTitle">Group title</span> <span rsf:id="directGroupLink">(<a rsf:id="payload-component" href="take_eval.html" title="direct url to the evaluation for this group">link</a>)</span>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign_select.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign_select.html
@@ -60,7 +60,7 @@
         </div>
         <p rsf:id="instruction" class="instructionText clear">Choose the instructors to be included in the above evaluation.</p>
         <div class="selectTable">
-        	<table border="0" cellspacing="0" cellpadding="3" style="width:90%" class="listHier lines nolines ">
+        	<table style="width:90%" class="evalsysTable ">
                 <thead>
                 <tr>
                     <th>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign_select.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assign_select.html
@@ -26,7 +26,7 @@
 <h2 class="titleHeader" id="title" style="display:none;" rsf:id="title">Select Instructors from ABC123 for Eval Name</h2>
     <form rsf:id="form" action="modify_template" method="post" id="basic-form">
 		<div rsf:id="selectInstructorTA:">
-            <p rsf:id="select-instructions" class="instruction" style="clear:both;">
+            <p rsf:id="select-instructions" class="instructionText" style="clear:both;">
                     These options control which Instructor and Teaching Assistant questions are repeated in the evaluation.
             </p>
             <!-- Instructors Options -->
@@ -58,7 +58,7 @@
               <label rsf:id="radioLabel" for="radio6">Respondents may select multiple TAs to evaluate</label>
             </div>
         </div>
-        <p rsf:id="instruction" class="instruction clear">Choose the instructors to be included in the above evaluation.</p>
+        <p rsf:id="instruction" class="instructionText clear">Choose the instructors to be included in the above evaluation.</p>
         <div class="selectTable">
         	<table border="0" cellspacing="0" cellpadding="3" style="width:90%" class="listHier lines nolines ">
                 <thead>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assignments.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assignments.html
@@ -37,12 +37,12 @@
             <li>
                 <a rsf:id="control-evaluations-link" href="control_evaluations.html">My Evaluations</a>
             </li>
-            <li class="lastCrumb" rsf:id="msg=evaluationassignments.page.title">
+            <li class="lastCrumbNoFloat" rsf:id="msg=evaluationassignments.page.title">
                 Display Assignments
             </li>
         </ul>
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
                 <li>
                     Message for user here
                 </li>
@@ -62,7 +62,7 @@
             Individual Groups
         </h4>
         <p rsf:id="noGroupsSelected" class="instructionText"></p>
-        <table rsf:id="showSelectedGroups:" border="0" cellspacing="0" cellpadding="0" style="width:90%" class="listHier lines nolines">
+        <table rsf:id="showSelectedGroups:" style="width:90%" class="evalsysTable">
             <thead>
                 <tr>
                     <th>
@@ -102,7 +102,7 @@
                 Individual Hierarchy Nodes:
             </h4>
             <p rsf:id="noNodesSelected"  class="instructionText"></p>
-            <table rsf:id="showSelectedNodes:" border="0" cellspacing="0" cellpadding="0" style="width:90%" class="listHier lines nolines">
+            <table rsf:id="showSelectedNodes:" style="width:90%" class="evalsysTable">
                 <thead>
                     <tr>
                         <th>
@@ -125,7 +125,7 @@
                 <tr rsf:id="nodes:groups">
                     <td colspan="2">
                         <p rsf:id="noGroupsForNode" class="instructionText"></p>
-                        <table rsf:id="nodeGroupTable:" border="0" cellspacing="0" cellpadding="0" style="width:90%" align="center" class="listHier lines nolines">
+                        <table rsf:id="nodeGroupTable:" style="width:90%" align="center" class="evalsysTable">
 						   <thead>
 						        <tr>
 						             <th width="60%">

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assignments.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_assignments.html
@@ -51,17 +51,17 @@
         <h3 rsf:id="msg=evaluationassignments.page.title">Evaluation Display Assignments</h3>
         <div>
             <a rsf:id="modifyAssignmentsLink" href="evaluation_assign.html">Modify evaluation assignments</a>
-            <p rsf:id="modifyAssignmentsInfoMsg" class="instruction"></p>
+            <p rsf:id="modifyAssignmentsInfoMsg" class="instructionText"></p>
         </div>
-        <p rsf:id="msg=evaluationassignments.info"  class="instruction" >
+        <p rsf:id="msg=evaluationassignments.info"  class="instructionText" >
             This shows the current groups and hierarchy nodes that your evaluation is assigned to
         </p>
-        <p class="elementAlertFront instruction" rsf:id="eval-instructions-group-notpublished">
+        <p class="elementAlertFront instructionText" rsf:id="eval-instructions-group-notpublished">
 			This denotes a site that are currently unpublished. Make sure you publish it otherwise students will not be notified via email or given access to complete this evaluation.</p>
         <h4 rsf:id="msg=evaluationassignments.groups.header">
             Individual Groups
         </h4>
-        <p rsf:id="noGroupsSelected" class="instruction"></p>
+        <p rsf:id="noGroupsSelected" class="instructionText"></p>
         <table rsf:id="showSelectedGroups:" border="0" cellspacing="0" cellpadding="0" style="width:90%" class="listHier lines nolines">
             <thead>
                 <tr>
@@ -101,7 +101,7 @@
             <h4 rsf:id="msg=evaluationassignments.nodes.header">
                 Individual Hierarchy Nodes:
             </h4>
-            <p rsf:id="noNodesSelected"  class="instruction"></p>
+            <p rsf:id="noNodesSelected"  class="instructionText"></p>
             <table rsf:id="showSelectedNodes:" border="0" cellspacing="0" cellpadding="0" style="width:90%" class="listHier lines nolines">
                 <thead>
                     <tr>
@@ -124,7 +124,7 @@
                 </tr>
                 <tr rsf:id="nodes:groups">
                     <td colspan="2">
-                        <p rsf:id="noGroupsForNode" class="instruction"></p>
+                        <p rsf:id="noGroupsForNode" class="instructionText"></p>
                         <table rsf:id="nodeGroupTable:" border="0" cellspacing="0" cellpadding="0" style="width:90%" align="center" class="listHier lines nolines">
 						   <thead>
 						        <tr>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_create.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_create.html
@@ -35,12 +35,13 @@
 
 <div>
 	<ul class="breadCrumb">
-		<li ><a rsf:id="summary-link" href="summary.html">Summary</a></li><li class="lastCrumb" rsf:id="msg=starteval.page.title">Start Evaluation</li>
+		<li ><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+		<li class="lastCrumbNoFloat" rsf:id="msg=starteval.page.title">Start Evaluation</li>
 	</ul>
 </div>
 
 <div rsf:id="message-for:*" class="alertMessage">
-	<ul style="margin:0px;">
+	<ul>
 		<li>Message for user here</li>
 	</ul>
 </div>
@@ -64,7 +65,7 @@
 		  <div rsf:id="chooseTemplate:">
 		  	<h4 rsf:id="msg=starteval.choose.template.header">Choose Template:</h4>
 			<p rsf:id="msg=starteval.choose.template.desc" class="instructionText">Select the template to use for this evaluation. Templates define the questions used.</p>
-				<table border = "0" cellspacing = "0" cellpadding = "0"  class="listHier lines nolines" style="width:60%">
+				<table class="evalsysTable" style="width:60%">
 					<tr>
 						<th id="titleCol"><span rsf:id="msg=starteval.template.title.header">Template Title</span></th>
 						<th id="ownerCol"><span rsf:id="msg=starteval.template.ownder.header">Owner</span></th>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_create.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_create.html
@@ -56,14 +56,14 @@
 			<div rsf:id="instructions:">
 		    	 <textarea name="instructions-dummy" rsf:id="instructions-dummy" rows="4" cols="60"></textarea>
 			 </div>
-			 <p class="instruction textPanelFooter"><span rsf:id="msg=starteval.instructions.desc">these will appear at the top of the evaluation</span></p>
+			 <p class="instructionText textPanelFooter"><span rsf:id="msg=starteval.instructions.desc">these will appear at the top of the evaluation</span></p>
 		 </div> 
 		
           <!-- This block (choose template) is not visible if the user came 
 			 from a screen where they had already chosen the template. -->
 		  <div rsf:id="chooseTemplate:">
 		  	<h4 rsf:id="msg=starteval.choose.template.header">Choose Template:</h4>
-			<p rsf:id="msg=starteval.choose.template.desc" class="instruction">Select the template to use for this evaluation. Templates define the questions used.</p>
+			<p rsf:id="msg=starteval.choose.template.desc" class="instructionText">Select the template to use for this evaluation. Templates define the questions used.</p>
 				<table border = "0" cellspacing = "0" cellpadding = "0"  class="listHier lines nolines" style="width:60%">
 					<tr>
 						<th id="titleCol"><span rsf:id="msg=starteval.template.title.header">Template Title</span></th>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_notifications.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_notifications.html
@@ -52,7 +52,7 @@
 
 		<form rsf:id="emailForm" name="emailForm" method="post">
 			<div style="width:80%">
-				<p rsf:id="msg=modifyemail.modify.text.instructions" class="instruction">Modify the suggested text or enter new text for the reminder email. Please note when sending the email the bracketed values will be substituted with actual values. You may use these values in your reminder email.</p>
+				<p rsf:id="msg=modifyemail.modify.text.instructions" class="instructionText">Modify the suggested text or enter new text for the reminder email. Please note when sending the email the bracketed values will be substituted with actual values. You may use these values in your reminder email.</p>
 				<div rsf:id="email_templates_fieldhints" class="highlightPanel" style="background:#eee;">
 ${EvalTitle} - the title of this evaluation <br/>
 ${EvalStartDate} - the start date of this evaluation <br/>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_notifications.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_notifications.html
@@ -33,11 +33,13 @@
        <div rsf:id="navIntraTool:" class="navIntraTool"/>
 
         <ul class="breadCrumb">
-            <li><a rsf:id="summary-link" href="summary.html">Summary</a></li><li><a rsf:id="control-evaluations-link" href="control_evaluations.html">My Evaluations</a></li><li class="lastCrumb"><a rsf:id="evalSettingsLink" href="evaluation_settings.html">Evaluation Settings</a></li>
+            <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+            <li><a rsf:id="control-evaluations-link" href="control_evaluations.html">My Evaluations</a></li>
+            <li class="lastCrumb"><a rsf:id="evalSettingsLink" href="evaluation_settings.html">Evaluation Settings</a></li>
         </ul>
 
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
                 <li>Message for user here</li>
             </ul>
         </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_responders.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_responders.html
@@ -33,11 +33,13 @@
        <div rsf:id="navIntraTool:" class="navIntraTool"/>
 
         <ul class="breadCrumb">
-            <li><a rsf:id="summary-link" href="summary.html">Summary</a></li><li><a rsf:id="control-evaluations-link" href="control_evaluations.html">My Evaluations</a></li><li class="lastCrumb"><a rsf:id="eval-settings-link" href="evaluation_settings.html">Evaluation Settings</a></li>
+            <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+            <li><a rsf:id="control-evaluations-link" href="control_evaluations.html">My Evaluations</a></li>
+            <li class="lastCrumb"><a rsf:id="eval-settings-link" href="evaluation_settings.html">Evaluation Settings</a></li>
         </ul>
 
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
                 <li>Message for user here</li>
             </ul>
         </div>
@@ -56,7 +58,7 @@
                     <span rsf:id="responseGroupStats" style="font-weight: bold;"><!-- evalresponders.stats -->10/100</span>
                     <a rsf:id="responseGroupEmailLink" href="evalaution_notifications.html"><!-- evalresponders.notifications.link -->Send email message to participants</a>
                 </div>
-                <table rsf:id="showGroupResponses:" border="0" cellspacing="0" cellpadding="0" style="width: 90%" class="listHier lines nolines">
+                <table rsf:id="showGroupResponses:" style="width: 90%" class="evalsysTable">
                     <thead>
                         <tr>
                             <th><span rsf:id="msg=evalresponders.user.name">Name</span></th>

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_settings.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_settings.html
@@ -63,7 +63,7 @@
                    <textarea id="instructions-dummy" name="instructions-dummy" rows="4" cols="60"></textarea>
                  </div>
                  <span rsf:id="instructions_disabled"></span>
-                 <p class="instruction textPanelFooter">
+                 <p class="instructionText textPanelFooter">
                      <span rsf:id="msg=evalsettings.instructions.desc">these will appear at the top of the evaluation</span>
                  </p>
               </div> 
@@ -71,7 +71,7 @@
               <!-- This block (choose template) is not visible if user has chosen a template or already assigned -->
               <div rsf:id="chooseTemplate:" class="longtext">
               <h4 rsf:id="msg=starteval.choose.template.header">Choose Template:</h4>
-              <p rsf:id="msg=starteval.choose.template.desc" class="instruction">Select the template to use for this evaluation. Templates define the questions used.</p>
+              <p rsf:id="msg=starteval.choose.template.desc" class="instructionText">Select the template to use for this evaluation. Templates define the questions used.</p>
                   <table border = "0" cellspacing = "0" cellpadding = "0"  class="listHier lines nolines" style="width:60%">
                       <tr>
                           <th id="titleCol"><span rsf:id="msg=starteval.template.title.header">Template Title</span></th>
@@ -98,7 +98,7 @@
 			<fieldset class="visibleFS">
 				<legend rsf:id="msg=evalsettings.dates.header">Evaluation Dates:</legend>
                     <div class="shorttext">
-                        <span rsf:id="current_date" class="instruction textPanelFooter">
+                        <span rsf:id="current_date" class="instructionText textPanelFooter">
                             Today is Oct 29, 1975
                         </span>
                     </div>
@@ -106,7 +106,7 @@
 						<label rsf:id="msg=evalsettings.start.date.header" for="startDate">Start Date:</label>
 						<input rsf:id="startDate:" type="hidden" id="dateStart" name="dateStart" value="MM/DD/YYYY" size="15" maxlength="15"/>
                         <span rsf:id="startDate_disabled" />
-						<span rsf:id="msg=evalsettings.start.date.desc"  class="instruction textPanelFooter">
+						<span rsf:id="msg=evalsettings.start.date.desc"  class="instructionText textPanelFooter">
 							Users may begin submitting evaluation responses on this date
 						</span>
 					</div>
@@ -114,7 +114,7 @@
 						<label rsf:id="msg=evalsettings.due.date.header" for="dueDate">Due Date:</label>
 							<input rsf:id="dueDate:" type="hidden" name="dueDate" value="MM/DD/YYYY" size="15" maxlength="15"/>
                         <span rsf:id="dueDate_disabled" />
-						<span rsf:id="msg=evalsettings.due.date.desc" class="instruction textPanelFooter">
+						<span rsf:id="msg=evalsettings.due.date.desc" class="instructionText textPanelFooter">
 							Evaluation ends on this date, no more responses after this date
 						</span>
 					</div>
@@ -124,7 +124,7 @@
 							<input rsf:id="stopDate:" type="hidden" id="stopDate" name="stopDate" value="MM/DD/YYYY" size="15" maxlength="15"/>
 						</span>
                         <span rsf:id="stopDate_disabled" />
-						<span rsf:id="msg=evalsettings.stop.date.desc" class="instruction textPanelFooter">
+						<span rsf:id="msg=evalsettings.stop.date.desc" class="instructionText textPanelFooter">
 							Users may still submit responses up until this date (defines a grace period)
 						</span>
 					</div>
@@ -136,7 +136,7 @@
 				<div rsf:id="sectionAwareness:" class="checkbox">
 					<input rsf:id="sectionAwareness" type="checkbox" name="sectionAwareness" id="sectionAwareness" />
 					<label rsf:id="msg=evalsettings.section.awareness.label" for="sectionAwareness">Should this evaluation be section aware?</label>
-					<p rsf:id="msg=evalsettings.section.awareness.note" class="instruction textPanelFooter indnt2">
+					<p rsf:id="msg=evalsettings.section.awareness.note" class="instructionText textPanelFooter indnt2">
 						By checking this checkbox, evaluators will only be presented with evaluation questions for evaluatee(s) in their
 						official section/roster for the site/group the evaluation is released to. Leaving this checkbox unchecked, the evaluators
 						will have the opportunity to evaluate all evaluatees in the site/group, regardless of what section/roster they
@@ -163,7 +163,7 @@
                       <label rsf:id="radioLabel" for="radioValue3">Public</label>
                   </span>
 
-                  <div rsf:id="resultsviewableadminnote" class="instruction">
+                  <div rsf:id="resultsviewableadminnote" class="instructionText">
                       Note that admins above in the hierarchy can view the results UNLESS results sharing is set to private
                   </div>
                 </div>
@@ -171,7 +171,7 @@
                      <label rsf:id="msg=evalsettings.view.date.header" for="viewDate">View Date:</label>
                      <input rsf:id="viewDate:" type="hidden" id="viewDate" name="viewDate" value="MM/DD/YYYY" size="15" maxlength="15"/>
                      <span rsf:id="viewDate_disabled" />
-                     <span rsf:id="msg=evalsettings.view.date.desc" class="instruction textPanelFooter">
+                     <span rsf:id="msg=evalsettings.view.date.desc" class="instructionText textPanelFooter">
                          Results are not viewable until this date
                      </span>
                 </div>
@@ -217,23 +217,23 @@
 				<div rsf:id="showBlankQuestionAllowedToStut:"  class="checkbox">
 					<input rsf:id="blankResponsesAllowed" type="checkbox" name="blankResponsesAllowed" id="blankResponsesAllowed" />
 					<label rsf:id="blankResponsesAllowed_label" for="blankResponsesAllowed">Blank non-text question responses allowed:</label>
-					<p rsf:id="msg=evalsettings.blank.responses.allowed.note" class="instruction textPanelFooter indnt2">Participants are not warned when responses are left blank if unchecked</p>
+					<p rsf:id="msg=evalsettings.blank.responses.allowed.note" class="instructionText textPanelFooter indnt2">Participants are not warned when responses are left blank if unchecked</p>
 				</div>	
 				<div rsf:id="showModifyResponsesAllowedToStu:" class="checkbox">
 					<input rsf:id="modifyResponsesAllowed" type="checkbox" name="modifyResponsesAllowed" id="modifyResponsesAllowed" />
 					<label rsf:id="modifyResponsesAllowed_label" for="modifyResponsesAllowed">Modification of responses allowed:</label>
-					<p rsf:id="msg=evalsettings.modify.responses.allowed.note"  class="instruction textPanelFooter indnt2">Participants may submit responses once only if unchecked</p>
+					<p rsf:id="msg=evalsettings.modify.responses.allowed.note"  class="instructionText textPanelFooter indnt2">Participants may submit responses once only if unchecked</p>
 				</div>
 				<div rsf:id="showAllRolesCanParticipate:" class="checkbox">
 					<input rsf:id="allRolesParticipate" type="checkbox" name="allRolesParticipate" id="allRolesParticipate" />
 					<label rsf:id="allRolesParticipate_label" for="allRolesParticipate">All Roles Can Participate:</label>
-					<p rsf:id="msg=evalsettings.all.roles.participate.note"  class="instruction textPanelFooter indnt2">This setting allows all roles to take the survey</p>
+					<p rsf:id="msg=evalsettings.all.roles.participate.note"  class="instructionText textPanelFooter indnt2">This setting allows all roles to take the survey</p>
 				</div>
 			</fieldset>
 
 			<fieldset class="visibleFS">
 				<legend rsf:id="msg=evalsettings.admin.settings.header">Administrative Settings</legend>
-				<p rsf:id="msg=evalsettings.auth.control.instructions" class="instruction">
+				<p rsf:id="msg=evalsettings.auth.control.instructions" class="instructionText">
 					This setting allows you to choose whether to require authentication to take this evaluation
 				</p>
 				<p class="shorttext">
@@ -244,7 +244,7 @@
 						<option value="NONE">None (anonymous allowed)</option>
 					</select>
 				</p>	
-				<p  rsf:id="instructor-opt-instructions"  class="instruction">
+				<p  rsf:id="instructor-opt-instructions"  class="instructionText">
 					This setting allows you to give the instructor control over whether to use the evaluation (or simply require them to).
 				</p>
 				<p class="shorttext">
@@ -262,7 +262,7 @@
             <fieldset rsf:id="selectInstructorTA:" class="visibleFS">
                 <legend rsf:id="msg=evalsettings.selection.header">Instructor / Teaching Assistant selection:</legend>
                 <div class="shorttext">
-                    <span rsf:id="msg=evalsettings.selection.instruction" class="instruction">
+                    <span rsf:id="msg=evalsettings.selection.instruction" class="instructionText">
                         These options control which Instructor and Teaching Assistant questions are repeated in the evaluation.
                   </span>
                 </div>
@@ -300,7 +300,7 @@
 			<fieldset rsf:id="showEvalExtras:" class="visibleFS">
 				<legend rsf:id="msg=evalsettings.extra.settings.header">Evaluation Extras:</legend>
                 <div rsf:id="showCategory:">
-  					<p  rsf:id="msg=evalsettings.extra.category.instructions" class="instruction">
+  					<p  rsf:id="msg=evalsettings.extra.category.instructions" class="instructionText">
   						The eval category is used to group related evaluations and for the category view
   					</p>
   					<p class="shorttext">
@@ -310,7 +310,7 @@
   					</p>
                  </div>
                  <div rsf:id="showEvalTermId:">
-  					<p  rsf:id="msg=evalsettings.extra.eval.term.id.instructions" class="instruction">
+  					<p  rsf:id="msg=evalsettings.extra.eval.term.id.instructions" class="instructionText">
   						The eval term ID is used to hold extra information for external use.
   					</p>
   					<p class="shorttext">
@@ -322,10 +322,10 @@
 
 			<fieldset class="visibleFS">
 				<legend rsf:id="msg=evalsettings.reminder.settings.header">Evaluation Notifications</legend>
-                <p class="instruction">
+                <p class="instructionText">
                     <span rsf:id="msg=evalsettings.emails.instructions">Extra instructions</span>
                 </p>
-				<p class="instruction">
+				<p class="instructionText">
 					<span rsf:id="msg=evalsettings.available.mail.desc">A notification email is sent out to all students assigned to an evaluation the morning of the day the evaluation goes live. Preview and edit the email template by clicking the link.</span>
 					<a href="preview_email.html" name="emailAvailable_link" rsf:id="emailAvailable_link" target="_blank">Evaluation Available</a>
                     <span rsf:id="msg=evalsettings.emails.appropriate">Note about how the default email templates are made for course evals</span>
@@ -343,14 +343,14 @@
   							<option value="2">Every Other Day</option>
   						</select>
   					</p>
- 					<p class="instruction" style="clear:both">
+ 					<p class="instructionText" style="clear:both">
   						<span rsf:id="msg=evalsettings.reminder.mail.desc">A reminder email is sent out to all students who have not yet completed the evaluation at the interval specified above. Preview and edit the email template by clicking the link.</span>
   						<a href="preview_email.html" name="emailReminder_link" rsf:id="emailReminder_link" target="_blank">(View/Change this email?)</a>
                         <span rsf:id="msg=evalsettings.emails.appropriate">Note about how the default email templates are made for course evals</span>
   					</p>
                 </div>
                 <div rsf:id="reminderFromAddress:">
-					<p class="instruction" style="clear:both">
+					<p class="instructionText" style="clear:both">
     					<span rsf:id="eval-from-email-note">All emails will be sent from helpdesk@institution.edu unless overridden below.</span>
 					</p>
 					<div class="shorttext">

--- a/sakai-evaluation-tool/src/webapp/content/templates/evaluation_settings.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/evaluation_settings.html
@@ -37,11 +37,13 @@
        <div rsf:id="navIntraTool:" class="navIntraTool"/>
 
 		<ul class="breadCrumb">
-			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li><li rsf:id="eval-start-text">Add Evaluation</li><li class="lastCrumb"><a rsf:id="eval-settings-link" href="evaluation_settings.html">Evaluation Settings</a></li>
+			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li rsf:id="eval-start-text">Add Evaluation</li>
+			<li class="lastCrumb"><a rsf:id="eval-settings-link" href="evaluation_settings.html">Evaluation Settings</a></li>
 		</ul>
 
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
@@ -72,7 +74,7 @@
               <div rsf:id="chooseTemplate:" class="longtext">
               <h4 rsf:id="msg=starteval.choose.template.header">Choose Template:</h4>
               <p rsf:id="msg=starteval.choose.template.desc" class="instructionText">Select the template to use for this evaluation. Templates define the questions used.</p>
-                  <table border = "0" cellspacing = "0" cellpadding = "0"  class="listHier lines nolines" style="width:60%">
+                  <table class="evalsysTable" style="width:60%">
                       <tr>
                           <th id="titleCol"><span rsf:id="msg=starteval.template.title.header">Template Title</span></th>
                           <th id="ownerCol"><span rsf:id="msg=starteval.template.ownder.header">Owner</span></th>
@@ -175,7 +177,7 @@
                          Results are not viewable until this date
                      </span>
                 </div>
-				<table class="listHier" border="0" cellspacing="0" cellpadding="0" width="99%" style="margin:0" id="evaluation_show_results_area"><!-- DO NOT CHANGE THIS ID, it is used by JS logic -AZ -->
+				<table class="evalsysTable" width="99%" style="margin:0" id="evaluation_show_results_area"><!-- DO NOT CHANGE THIS ID, it is used by JS logic -AZ -->
 					<tr rsf:id="showResultsToStudents:" id="showResultsToStudents">
 						<td width="33%" class="checkbox">
 							<input rsf:id="studentViewResults" type="checkbox" name="student_view_results" id="studentViewResults" />

--- a/sakai-evaluation-tool/src/webapp/content/templates/messages.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/messages.html
@@ -25,7 +25,7 @@
 <body>
 
 <div rsf:id="message-for:*" class="alertMessage">
-	<ul style="margin:0px;">
+	<ul>
 		<li>Message for user here</li>
 	</ul>
 </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_adhoc_group.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_adhoc_group.html
@@ -39,7 +39,7 @@
   <h3 rsf:id="page-title">Modify or Create Adhoc Groups</h3>
   
   <div rsf:id="message-for:*" class="alertMessage">
-     <ul style="margin:0px;">
+     <ul>
         <li>Message for user here</li>
      </ul>
   </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_adhoc_group.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_adhoc_group.html
@@ -44,7 +44,7 @@
      </ul>
   </div>
   
-  <p class="instruction" rsf:id="msg=modifyadhocgroup.message.instructions">
+  <p class="instructionText" rsf:id="msg=modifyadhocgroup.message.instructions">
   	Please enter a group name and email addresses, one per line.
   </p>
   

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_email.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_email.html
@@ -40,7 +40,7 @@
 		</div>  
 
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_email.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_email.html
@@ -49,7 +49,7 @@
 
 		<form rsf:id="emailTemplateForm" name="emailTemplateForm" method="post">
 			<div style="width:80%">
-				<p rsf:id="msg=modifyemail.modify.text.instructions" class="instruction">Modify the suggested text or enter new text for the reminder email. Please note when sending the email the bracketed values will be substituted with actual values. You may use these values in your reminder email.</p>
+				<p rsf:id="msg=modifyemail.modify.text.instructions" class="instructionText">Modify the suggested text or enter new text for the reminder email. Please note when sending the email the bracketed values will be substituted with actual values. You may use these values in your reminder email.</p>
 				<div rsf:id="email_templates_fieldhints" class="highlightPanel" style="background:#eee;">
 ${EvalTitle} - the title of this evaluation <br/>
 ${EvalStartDate} - the start date of this evaluation <br/>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node.html
@@ -31,15 +31,19 @@
 <body>
 <div class="portletBody">
      <div rsf:id="navIntraTool:" class="navIntraTool"/>
-
-    <ul class="breadCrumb" style="clear: both; height: 1.5em">
-        <li style="float: left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-        <li style="float: left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-        <li style="float: left"><a rsf:id="hierarchy-toplink" href="hierarchy.html">Hierarchy</a></li>
-        <li style="float: left" rsf:id="page-title" class="lastCrumb" >Add / Modify</li>
+     <div rsf:id="message-for:*" class="alertMessage">
+        <ul>
+            <li>Message for user here</li>
+        </ul>
+    </div>
+    <ul class="breadCrumb">
+        <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+        <li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+        <li><a rsf:id="hierarchy-toplink" href="hierarchy.html">Hierarchy</a></li>
+        <li rsf:id="page-title" class="lastCrumbNoFloat" >Add / Modify</li>
     </ul>
     <h3 rsf:id="modify-location-message">Add/Modify Hierarchy Item under School Science</h3>
-    <form rsf:id="modify-node-form">
+    <form rsf:id="modify-node-form" class="inlineBlockForm">
         <p class="shorttext">
             <label rsf:id="title-label" for="node-title">Title</label>
             <input id="node-title" rsf:id="node-title" type="text"/>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_groups.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_groups.html
@@ -35,24 +35,30 @@
 <div class="portletBody">
      <div rsf:id="navIntraTool:" class="navIntraTool"/>
 
-    <ul class="breadCrumb" style="clear: both; height: 1.5em">
-        <li style="float: left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-        <li style="float: left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-        <li style="float: left"><a rsf:id="hierarchy-toplink" href="hierarchy.html">Hierarchy</a></li>
-        <li style="float: left" rsf:id="page-title" class="lastCrumb" >Add / Modify</li>
+    <ul class="breadCrumb">
+        <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+        <li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+        <li><a rsf:id="hierarchy-toplink" href="hierarchy.html">Hierarchy</a></li>
+        <li rsf:id="page-title" class="lastCrumbNoFloat" >Add / Modify</li>
     </ul>
     <h3 rsf:id="assign-groups-title">Assign groups for a hierarchy node</h3>
 
-    <form rsf:id="assign-groups-form" style="display: inline-block;">
+    <div rsf:id="message-for:*" class="alertMessage">
+        <ul>
+            <li>Message for user here</li>
+        </ul>
+    </div>
 
-        <div class="action" style="margin-bottom: 5px;">
+    <form rsf:id="assign-groups-form" class="inlineBlockForm">
+
+        <div class="action">
             <span class="cancelButton">
                 <a href="#" rsf:id="return-link1">Return to Control Hierarchy</a>
-                <input type="submit" value="Save Assigned Groups" rsf:id="save-groups-button1" class="active" accesskey="s" style="float: right;" />
+                <input type="submit" value="Save Assigned Groups" rsf:id="save-groups-button1" class="active" accesskey="s" />
             </span>
         </div>
 
-        <table id="groups-table">
+        <table class="evalsysTable">
             <thead>
                 <tr>
                     <th>
@@ -66,7 +72,7 @@
             <tbody>
                 <tr rsf:id="group-row:">
                     <td>
-                        <input class=" groupcheckbox "rsf:id="group-checkbox" type="checkbox" />
+                        <input class="groupcheckbox"rsf:id="group-checkbox" type="checkbox" />
                     </td>
                     <td>
                         <label rsf:id="group-title">Group Title</label>
@@ -78,7 +84,7 @@
         <div class="action">
             <span class="cancelButton">
                 <a href="#" rsf:id="return-link2">Return to Control Hierarchy</a>
-                <input type="submit" value="Save Assigned Groups" rsf:id="save-groups-button2" class="active" accesskey="s" style="float: right;" />
+                <input type="submit" value="Save Assigned Groups" rsf:id="save-groups-button2" class="active" accesskey="s" />
             </span>
         </div>
     </form>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_groups.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_groups.html
@@ -42,13 +42,8 @@
         <li style="float: left" rsf:id="page-title" class="lastCrumb" >Add / Modify</li>
     </ul>
     <h3 rsf:id="assign-groups-title">Assign groups for a hierarchy node</h3>
-    <!-- 
-    <p>
-      <span>Filter</span>
-      <input type="text" value="" id="filterinput" />
-    </p>
-    -->
-    <form rsf:id="assign-groups-form">
+
+    <form rsf:id="assign-groups-form" style="display: inline-block;">
 
         <div class="action" style="margin-bottom: 5px;">
             <span class="cancelButton">
@@ -57,10 +52,10 @@
             </span>
         </div>
 
-        <table border="0" cellspacing="0" cellpadding="0" class="listHier lines nolines" summary="placeholder summary">
+        <table id="groups-table">
             <thead>
                 <tr>
-                    <th width="3%">
+                    <th>
                         <input id="selectAllNone" type="checkbox" />
                         <span rsf:id="select-header">Select</span>
                     </th>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_perms.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_perms.html
@@ -38,17 +38,17 @@
 		
 		<div rsf:id="navIntraTool:" class="navIntraTool"/>
 		
-		<ul class="breadCrumb" style="clear: both; height: 1.5em">
-			<li style="float: left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-			<li style="float: left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-			<li style="float: left"><a rsf:id="hierarchy-toplink" href="hierarchy.html">Hierarchy</a></li>
-			<li style="float: left" rsf:id="page-title" class="lastCrumb" >Add / Modify</li>
+		<ul class="breadCrumb">
+			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+			<li><a rsf:id="hierarchy-toplink" href="hierarchy.html">Hierarchy</a></li>
+			<li rsf:id="page-title" class="lastCrumbNoFloat" >Add / Modify</li>
 		</ul>
 		
 		<h3 rsf:id="msg=modifynodeperms.page.title">Hierarchy Node Perms</h3>
 		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>
@@ -59,19 +59,19 @@
 			Page Instructions: Enter usernames or emails in the box and then select the permissions to apply to the users
 		</p>
 		
-		<form rsf:id="perms-form" method="post" style="display: inline-block;">
+		<form rsf:id="perms-form" method="post" class="inlineBlockForm">
 			
 			<input type="hidden" rsf:id="node-id" />
 
 			<!-- Clear changes and return to hierarchy UI buttons at the top of the form -->
-			<div class="action" style="margin-bottom: 5px;">
+			<div class="action">
 				<span class="cancelButton">
 					<a href="#" rsf:id="return-link1">Return to Control Hierarchy</a>
-					<input type="submit" rsf:id="cancel-changes-button1" style="float: right;" />
+					<input type="submit" rsf:id="cancel-changes-button1" />
 				</span>
 			</div>
 
-			<table id="user-perms-table">
+			<table class="evalsysTable">
 				
 				<thead>
 					<tr>
@@ -85,11 +85,11 @@
 					
 					<tr rsf:id="new-user:" class="userPermsRow">
 						
-						<td class="userInfo">
+						<td class="alignCenter">
 							<input type="text" rsf:id="user-eid" id="user-eid" />
 						</td>
 						
-						<td class="userPerms">
+						<td class="checkboxes">
 							<span rsf:id="perms-select"></span>
 							<span rsf:id="perm:">
 								<input type="checkbox" rsf:id="perm-checkbox" />
@@ -105,12 +105,12 @@
 					
 					<tr rsf:id="user:" class="userPermsRow">
 						
-						<td class="userInfo">
+						<td class="alignCenter">
 							<span rsf:id="user-info">Display Name (username)</span>
 							<input type="hidden" rsf:id="user-id" />
 						</td>
 						
-						<td class="userPerms">
+						<td class="checkboxes">
 							<span rsf:id="perms-select"></span>
 							<span rsf:id="perm:">
 								<input type="checkbox" rsf:id="perm-checkbox" />

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_perms.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_perms.html
@@ -55,7 +55,7 @@
 		
 		<div rsf:id="node-info">Node title (Node Description)</div>
 		
-		<p class="instruction" rsf:id="msg=modifynodeperms.instructions">
+		<p class="instructionText" rsf:id="msg=modifynodeperms.instructions">
 			Page Instructions: Enter usernames or emails in the box and then select the permissions to apply to the users
 		</p>
 		

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_rules.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_rules.html
@@ -55,10 +55,10 @@
 
             <div rsf:id="node-info">Node title (Node Description)</div>
 
-            <p class="instruction" rsf:id="instructions1">
+            <p class="instructionText" rsf:id="instructions1">
                 Page Instructions: blurb 1
             </p>
-            <p class="instruction" rsf:id="instructions2">
+            <p class="instructionText" rsf:id="instructions2">
                 Page Instructions: blurb 2
             </p>
 

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_rules.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_hierarchy_node_rules.html
@@ -38,17 +38,17 @@
         <div class="portletBody">
             <div rsf:id="navIntraTool:" class="navIntraTool"/>
 
-            <ul class="breadCrumb" style="clear: both; height: 1.5em">
-                <li style="float: left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-                <li style="float: left"><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
-                <li style="float: left"><a rsf:id="hierarchy-toplink" href="hierarchy.html">Hierarchy</a></li>
-                <li style="float: left" rsf:id="page-title" class="lastCrumb" >Add / Modify</li>
+            <ul class="breadCrumb">
+                <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+                <li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+                <li><a rsf:id="hierarchy-toplink" href="hierarchy.html">Hierarchy</a></li>
+                <li rsf:id="page-title" class="lastCrumbNoFloat" >Add / Modify</li>
             </ul>
 
             <h3 rsf:id="msg=modifynoderules.page.title">Hierarchy Node Rules</h3>
 
             <div rsf:id="message-for:*" class="alertMessage">
-                <ul style="margin:0px;">
+                <ul>
                     <li>Message for user here</li>
                 </ul>
             </div>
@@ -62,17 +62,17 @@
                 Page Instructions: blurb 2
             </p>
 
-            <form rsf:id="rules-form" method="post" style="display: inline-block;">
+            <form rsf:id="rules-form" method="post" class="inlineBlockForm">
                 <input type="hidden" rsf:id="node-id" />
 
-                <div class="action" style="margin-bottom: 5px;">
+                <div class="action">
                     <span class="cancelButton">
                         <a href="#" rsf:id="return-link1">Return to Control Hierarchy</a>
-                        <input type="submit" rsf:id="cancel-changes-button1" style="float: right;" />
+                        <input type="submit" rsf:id="cancel-changes-button1" />
                     </span>
                 </div>
 
-                <table id="rules-table">
+                <table class="evalsysTable">
                     <thead>
                         <tr>
                             <th rsf:id="rules-header">Criteria</th>
@@ -81,8 +81,8 @@
                     </thead>
 
                     <tbody>
-                        <tr rsf:id="new-rule:" class="userPermsRow">
-                            <td class="userInfo">
+                        <tr rsf:id="new-rule:">
+                            <td class="alignCenter">
                                 <select rsf:id="new-rule-option-selection" id="new-rule-option-selection">
                                     <option value="SITE" selected="selected">Site Title</option>
                                     <option value="SECTION">Section Title</option>
@@ -102,8 +102,8 @@
                             </td>
                         </tr>
 
-                        <tr rsf:id="rule:" class="userPermsRow">
-                            <td class="userInfo">
+                        <tr rsf:id="rule:">
+                            <td class="alignCenter">
                                 <select rsf:id="existing-rule-option-selection" id="existing-rule-option-selection">
                                     <option value="SITE" selected="selected">Site Title</option>
                                     <option value="SECTION">Section Title</option>
@@ -131,7 +131,7 @@
                 <div class="action">
                     <span class="cancelButton">
                         <a href="#" rsf:id="return-link2">Return to Control Hierarchy</a>
-                        <input type="submit" rsf:id="cancel-changes-button2" style="float: right;" />
+                        <input type="submit" rsf:id="cancel-changes-button2" />
                     </span>
                 </div>
             </form>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_item.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_item.html
@@ -25,7 +25,7 @@
 <body>
   <div class="portletBody">
     <div rsf:id="message-for:*" class="alertMessage">
-      <ul style="margin: 0px;">
+      <ul>
         <li>Message for user here</li>
       </ul>
     </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_item.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_item.html
@@ -224,7 +224,7 @@
       </fieldset>
       <div class="act">
         <input rsf:id="save-item-action" type="submit" value="Save item" class="active submit" accesskey="s" />
-        <input rsf:id="cancel-button" type="button" value="Cancel" class="close" accesskey="x" />
+        <input rsf:id="cancel-button" type="button" value="No" class="cancel" accesskey="x" onclick="$(document).trigger('close.facebox')" />
       </div>
     </form>
   </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_item.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_item.html
@@ -34,7 +34,7 @@
       <div class="viewNav">
         <span rsf:id="item-header">Item:</span>
         <!--//gsilver: this always seems to return "Scaled" -->
-        <span rsf:id="item-classification" class="highlight">classification</span> (<span rsf:id="added-by-item-owner" class="instruction">added
+        <span rsf:id="item-classification" class="highlight">classification</span> (<span rsf:id="added-by-item-owner" class="instructionText">added
           by username</span>)
       </div>
       <div class="listNav itemAction">
@@ -47,7 +47,7 @@
     <form rsf:id="item-form" method="post" id="item-form">
 
       <p>
-        <span rsf:id="item-text-header">Item Text:</span> <span rsf:id="item-text-instruction" class="instruction">(this is the question or
+        <span rsf:id="item-text-header">Item Text:</span> <span rsf:id="item-text-instruction" class="instructionText">(this is the question or
           statement that the evaluator will respond to)</span>
       </p>
       <div class="longtext evalEditorSmall">
@@ -117,11 +117,11 @@
         <div class="checkbox">
           <input rsf:id="item-expert" type="checkbox" id="item-expert" />
           <label rsf:id="item-expert-header" for="item-expert">Expert Item:</label>
-          <span rsf:id="item-expert-instruction" class="instruction">indicates that this item was authored by an expert</span>
+          <span rsf:id="item-expert-instruction" class="instructionText">indicates that this item was authored by an expert</span>
         </div>
         <p>
           <span rsf:id="expert-desc-header">Expert Description:</span>
-          <span rsf:id="expert-desc-instruction" class="instruction">this text describes the appropriate usage of this item for template authors</span>
+          <span rsf:id="expert-desc-instruction" class="instructionText">this text describes the appropriate usage of this item for template authors</span>
         </p>
         <div class="evalEditorSmall">
           <div>
@@ -163,7 +163,7 @@
       <fieldset rsf:id="showItemDisplayHints:" class="visibleFS evalEditorSmall">
         <legend rsf:id="item-display-hint-header">Display Setting Hints</legend>
         <div id="nonBlockSettings">
-          <div rsf:id="item-display-hint-instruction" class="instruction">these optional settings allow the item author to provide hints as to
+          <div rsf:id="item-display-hint-instruction" class="instructionText">these optional settings allow the item author to provide hints as to
             how this item should be displayed</div>
 
           <p rsf:id="show-scale-display:" class="longtext">

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_scale.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_scale.html
@@ -95,7 +95,7 @@
 
 	
 	<h4 rsf:id="msg=modifyscale.scale.ideal.note.start">Ideal</h4>
-	<p class="instruction" rsf:id="msg=modifyscale.scale.ideal.note.main.text" >
+	<p class="instructionText" rsf:id="msg=modifyscale.scale.ideal.note.main.text" >
 		Indicate the position of the "best" answer in this scale (used for graphs and coloring)
 	</p>	
 

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_scale.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_scale.html
@@ -43,12 +43,14 @@
 
 <div>
 	<ul class="breadCrumb">
-		<li><a rsf:id="summary-link" href="summary.html">Summary</a></li><li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li><li rsf:id="msg=modifyscale.page.title" class="lastCrumb">Add/Edit Scale</li>
+		<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+		<li><a rsf:id="administrate-link" href="administrate.html">Administrate</a></li>
+		<li rsf:id="msg=modifyscale.page.title" class="lastCrumbNoFloat">Add/Edit Scale</li>
 	</ul>
 </div>
 
 <div rsf:id="message-for:*" class="alertMessage">
-	<ul style="margin:0px;">
+	<ul>
 		<li>Message for user here</li>
 	</ul>
 </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_template.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_template.html
@@ -36,12 +36,12 @@
          <ul rsf:id="breadcrumbs:" class="breadCrumb">
              <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
              <li><a rsf:id="control-templates-link" href="control_templates.html">My Templates</a></li>
-             <li class="lastCrumb" rsf:id="template-title-desc-title">Edit Template Title/Desc.</li>
+             <li class="lastCrumbNoFloat" rsf:id="template-title-desc-title">Edit Template Title/Desc.</li>
          </ul>
     <h2 rsf:id="msg=modifytemplatetitledesc.page.title" class="titleHeader pageHeaderOnPage">Add/Modify Item</h2>
 
     <div rsf:id="message-for:*" class="alertMessage">
-        <ul style="margin:0px;">
+        <ul>
             <li>Message for user here</li>
         </ul>
     </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_template.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_template.html
@@ -56,7 +56,7 @@
             <label rsf:id="description-header" class="block" for="description">Description</label>
             <textarea rsf:id="description" id="description" name="description" cols="70" rows="3"> </textarea>
 
-            <p class="instruction textPanelFooter" rsf:id="description-note">
+            <p class="instructionText textPanelFooter" rsf:id="description-note">
                 For you or other admins. Place notes or comments about this template here.
             </p>
         </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_template_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_template_items.html
@@ -77,7 +77,7 @@
     <div class="navPanel">
     <div rsf:id="template-owner" style="display:none;" class="templateOwner">Owner</div>
       <div class="listNav">
-        <div class="instruction">
+        <div class="instructionText">
 		<span rsf:id="level-header-level">Current Level - </span> <span rsf:id="level-header-number" id="level-header-number">#</span> <span rsf:id="level-header-items"> existing items</span>
 		</div>
         <label rsf:id="add-item-note">Add Item:</label>
@@ -103,7 +103,7 @@
         <div class="itemOperations" id="orderInputs">
           <input rsf:id="revertOrderButton" type="button" disabled="disabled" value="Revert Order" id="revertOrderButton" />
           <input rsf:id="saveReorderButton" type="submit" disabled="disabled" value="Save Order" id="saveReorderButton" />
-          <span rsf:id="orderingInstructions" class="instruction" > Drag the items to reorder them and click save to set the new order or use the pulldowns to reorder a single item </span> </div>
+          <span rsf:id="orderingInstructions" class="instructionText" > Drag the items to reorder them and click save to set the new order or use the pulldowns to reorder a single item </span> </div>
         <div id="itemTable">
           <div id="itemList" class="itemList">
             <div rsf:id="item-row:" class="itemRow" id="item-row::0:">
@@ -145,7 +145,7 @@
                	<div id="itemTableBlock" class="itemTableBlock">
              			<a rsf:id="msg=modifytemplate.group.add.newitem" class="addItem" rel="faceboxAddNewGroupItem" href="#">Add new item</a>
                        <a rsf:id="msg=modifytemplate.group.add.existingitem" class="dropItem addItem" rel="faceboxAddGroupItems" href="#">Add existing item</a>  &nbsp;&nbsp; | &nbsp;
-					 <span  rsf:id="modifyblock-items-list-instructions" class="instruction">Drag and drop to rearrange the blocked items</span>
+					 <span  rsf:id="modifyblock-items-list-instructions" class="instructionText">Drag and drop to rearrange the blocked items</span>
 				<div rsf:id="itemRowBlock:" id="itemRowBlock::1:" class="itemRowBlock inlineEditable" style="padding:.2em;width:99%">
 							<input type="hidden" rsf:id="hidden-item-id" name="hidden-item-id" value="0" id="itemRowBlock::1:hidden-item-id" />
 							 <span rsf:id="item-block-num" id="itemRow::1:item-num" class="itemLabel">1</span>.&nbsp;
@@ -195,7 +195,7 @@
                <div id="itemTableBlock" class="itemTableBlock">
              			<a rsf:id="msg=modifytemplate.group.add.newitem" class="addItem" rel="faceboxAddNewGroupItem" href="#">Add new item</a>
                    <a rsf:id="msg=modifytemplate.group.add.existingitem" class="dropItem addItem" rel="faceboxAddGroupItems" href="#">Add existing item</a>  &nbsp;&nbsp; | &nbsp;
-					 <span rsf:id="modifyblock-items-list-instructions" class="instruction">Drag and drop to rearrange the blocked items</span>
+					 <span rsf:id="modifyblock-items-list-instructions" class="instructionText">Drag and drop to rearrange the blocked items</span>
 				<div rsf:id="itemRowBlock:" id="itemRowBlock::1:" class="itemRowBlock inlineEditable" style="padding:.2em;width:99%">
 							<input type="hidden" rsf:id="hidden-item-id" name="hidden-item-id" value="0" id="itemRow::1:hidden-item-id" />
 							<span rsf:id="item-block-num" id="itemRow::1:item-num" class="itemLabel">1</span>.&nbsp;
@@ -257,7 +257,7 @@
             <input type="hidden" name="templateItemIds"/>
             <input rsf:id="createBlockBtn" name="create_block_btn" id="createBlockBtn" type="button" value="Create Group" disabled="disabled" />
           </form>
-          <span rsf:id="blockInstructions"class="instruction"> Check the boxes next to a set of items and click Create Block to make a block with the chosen items </span> </div>
+          <span rsf:id="blockInstructions"class="instructionText"> Check the boxes next to a set of items and click Create Block to make a block with the chosen items </span> </div>
         <div class="cleaner">&nbsp;</div>
       </div>
     </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/modify_template_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/modify_template_items.html
@@ -59,7 +59,7 @@
 	<ul class="breadCrumb">
     <li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
     <li><a rsf:id="control-templates-link" href="control_templates.html">My Templates</a></li>
-    <li class="lastCrumb" rsf:id="modify-template-title">Edit Template</li>
+    <li class="lastCrumbNoFloat" rsf:id="modify-template-title">Edit Template</li>
   </ul>
   <div rsf:id="message-for:*" class="alertMessage" id="messageInformation">
     <ul style="margin:0px;">

--- a/sakai-evaluation-tool/src/webapp/content/templates/preview_email.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/preview_email.html
@@ -37,7 +37,7 @@
 	</ul>
 	
 	<h3 rsf:id="msg=previewemail.header">Preview of the text of the email that is sent out to students the day evaluation goes live</h3> 
-		<p rsf:id="msg=previewemail.desc" class="instruction">
+		<p rsf:id="msg=previewemail.desc" class="instructionText">
 			Please note when sending the email the bracketed values will be substituted with actual values.
 		</p>
 		<div style="width:70%">

--- a/sakai-evaluation-tool/src/webapp/content/templates/preview_eval.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/preview_eval.html
@@ -47,7 +47,7 @@
 	<div class="portletBody evaluation preview">
 		<ul class="breadCrumb">
 			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-			<li rsf:id="msg=previeweval.evaluation.title" class="lastCrumb">Previewing Template/Evaluation</li>
+			<li rsf:id="msg=previeweval.evaluation.title" class="lastCrumbNoFloat">Previewing Template/Evaluation</li>
 		</ul>
 
 		<div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/preview_eval.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/preview_eval.html
@@ -54,7 +54,7 @@
 			<h3 style="display:inline">
 				<span rsf:id="preview-title-prefix" class="highlight">Previewing Evaluation</span><span rsf:id="evalTitle">Evaluation title here</span>
 			</h3>
-			<span rsf:id="show-group-title:" class="instruction">
+			<span rsf:id="show-group-title:" class="instructionText">
 				(<span rsf:id="group-title-header">Group:</span>
 				<span rsf:id="group-title">Group title here</span>)
 			</span>
@@ -69,7 +69,7 @@
 
 		<div rsf:id="show-eval-instructions:" style="margin:.5em 0">
 			<h5 rsf:id="eval-instructions-header" style="display:inline">Instructions:</h5>
-			<div rsf:id="eval-instructions" class="instruction" style="display:inline">Evaluation instructions would go here if any have been specified. This block may be up to 4000 chars.</div>
+			<div rsf:id="eval-instructions" class="instructionText" style="display:inline">Evaluation instructions would go here if any have been specified. This block may be up to 4000 chars.</div>
 		</div>
 		
 		<div class="content">

--- a/sakai-evaluation-tool/src/webapp/content/templates/preview_expert_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/preview_expert_items.html
@@ -31,7 +31,7 @@
 <body>
 	<div class="portletBody">		
 
-	<table cellpadding="0" cellspacing="0" class="listHier lines nolines" style="width:auto;min-width:100%">
+	<table class="evalsysTable" style="width:auto;min-width:100%">
 		<thead>
 			<tr rsf:id="expert-item-header-row:">
 				<th><b><span rsf:id="title-label">Category</span>:  <span rsf:id="title">General</span></b></th>

--- a/sakai-evaluation-tool/src/webapp/content/templates/preview_expert_items.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/preview_expert_items.html
@@ -43,7 +43,7 @@
 					<label rsf:id="item-label" for="id1">
 						<span rsf:id="item-text">Item Text (the text entered for the item itself will appear here, it is possibly quite long</span>
 					</label>
-					<div class="instruction">
+					<div class="instructionText">
 						<span rsf:id="item-scale">Item Scale (the title of the scale and the points in parens)</span>
 						<span rsf:id="item-expert-desc">Expert description (the description of what this item is good for assessing and where it should be used</span>
 					</div>
@@ -52,7 +52,7 @@
 			<tr rsf:id="display-expert-item-list:">
 				<td>
 					<span rsf:id="display-item-text">Item Text (the text entered for the item itself will appear here, it is possibly quite long</span>
-					<div class="instruction">
+					<div class="instructionText">
 						<span rsf:id="display-item-scale" class="itemsScale">Item Scale (the title of the scale and the points in parens)</span>
 						<span rsf:id="display-item-expert-desc" class="itemsDesc">Expert description (the description of what this item is good for assessing and where it should be used</span>
 					</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/remove_evaluation.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/remove_evaluation.html
@@ -33,11 +33,13 @@
 	<div class="portletBody">
 		
 		<ul class="breadCrumb">
-			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li><li><a rsf:id="control-evaluations-link" href="control_evaluations.html">My Evaluations</a></li><li class="lastCrumb" rsf:id="msg=removeeval.page.title">Remove Evaluation</li>
+			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li><a rsf:id="control-evaluations-link" href="control_evaluations.html">My Evaluations</a></li>
+			<li class="lastCrumbNoFloat" rsf:id="msg=removeeval.page.title">Remove Evaluation</li>
 		</ul>
 		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/remove_evaluation.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/remove_evaluation.html
@@ -44,7 +44,7 @@
 
 		<p class="alertMessage"  rsf:id="remove-eval-confirm-name">Are you sure you want to remove evaluation (eval title)? The removal is permanant.</p>
 
-		<p rsf:id="msg=removeeval.note" class="instruction">All data related to the evaluation will be removed permanantly.</p>
+		<p rsf:id="msg=removeeval.note" class="instructionText">All data related to the evaluation will be removed permanantly.</p>
 
 		<table border="0" cellpadding="0" cellspacing="0" class="itemSummary" summary="summary placeholder">
 			<tr>

--- a/sakai-evaluation-tool/src/webapp/content/templates/remove_expert_item.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/remove_expert_item.html
@@ -30,7 +30,7 @@
 <body>
     <div class="portletBody">
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
                 <li>
                     Message for user here
                 </li>

--- a/sakai-evaluation-tool/src/webapp/content/templates/remove_item.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/remove_item.html
@@ -34,7 +34,7 @@
       <li> <span rsf:id="remove-item-confirm-text"> Are you sure you want to remove item ## (shown below) from Template_Title? The removal is permanent. </span> </li>
     </ul>
   </div>
-  <div rsf:id="remove-item-block-text" class="instruction"> Block child items will be split out and placed into the template in the same location as block occupied and in the same order </div>
+  <div rsf:id="remove-item-block-text" class="instructionText"> Block child items will be split out and placed into the template in the same location as block occupied and in the same order </div>
   <div rsf:id="inUse:"> <b rsf:id="inUseWarning">Warning: this item is currently in use in X templates, removing it will only cause it to be hidden</b>
     <ol>
       <li rsf:id="items:"> <span rsf:id="itemInfo">Info about the template</span> </li>

--- a/sakai-evaluation-tool/src/webapp/content/templates/remove_item.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/remove_item.html
@@ -26,7 +26,6 @@
 
 <div class="portletBody">
 
-<div rsf:id="navIntraTool:" class="navIntraTool"/>
     
 <div id="removeBody"> 
   <div class="messageComfirm">

--- a/sakai-evaluation-tool/src/webapp/content/templates/remove_scale.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/remove_scale.html
@@ -39,12 +39,12 @@
             <li>
                 <a rsf:id="control-scales-link" href="control_scales.html">Control Scales</a>
             </li>
-            <li rsf:id="msg=removescale.page.title" class="lastCrumb">
+            <li rsf:id="msg=removescale.page.title" class="lastCrumbNoFloat">
                 Remove Scale
             </li>
         </ul>
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
                 <li>
                     Message for user here
                 </li>

--- a/sakai-evaluation-tool/src/webapp/content/templates/remove_template.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/remove_template.html
@@ -33,18 +33,20 @@
 	   <div rsf:id="navIntraTool:" class="navIntraTool"/>
 	
 		<ul class="breadCrumb">
-			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li><li><a rsf:id="control-templates-link" href="control_templates.html">My Templates</a></li><li class="lastCrumb" rsf:id="remove-template-title">Remove Template</li>
+			<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+			<li><a rsf:id="control-templates-link" href="control_templates.html">My Templates</a></li>
+			<li class="lastCrumbNoFloat" rsf:id="remove-template-title">Remove Template</li>
 		</ul>
 		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
-				<li>Message for user here</li>                                                    
+			<ul>
+				<li>Message for user here</li>
 			</ul>
 		</div>
 		
 		<h3 rsf:id="remove-template-title"></h3>
 		<div rsf:id="cannot-remove-message" class="alertMessage"></div>
-																																												  
+
 		<div rsf:id="removeDiv:">
 			<div class="alertMessage">
 				<span rsf:id="remove-template-confirm-text">Are you sure you want to remove template NAME? The removal is permanant.</span>

--- a/sakai-evaluation-tool/src/webapp/content/templates/report_groups.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/report_groups.html
@@ -58,7 +58,7 @@
 
 		<form name="report_groups_form" rsf:id="report-groups-form" method="post" >
 			
-			<p rsf:id="report-group-main-message" class="instruction">
+			<p rsf:id="report-group-main-message" class="instructionText">
 				Choose the groups you would like to view results for. Results will be displayed in aggregate.
 			</p>
 			<span rsf:id="selectHolder"></span>

--- a/sakai-evaluation-tool/src/webapp/content/templates/report_groups.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/report_groups.html
@@ -40,12 +40,12 @@
 		<div>
 			<ul class="breadCrumb">
 				<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-				<li rsf:id="report-groups-title"  class="lastCrumb">Choose Report Groups</li>
+				<li rsf:id="report-groups-title" class="lastCrumbNoFloat">Choose Report Groups</li>
 			</ul>
 		</div>
 		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/report_view.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/report_view.html
@@ -57,7 +57,7 @@
                <input rsf:id="newReportStyle" type="checkbox" name="newReportStyle" id="newReportStyle" onclick="evalsys.toggleReportFormat( 'eval_report_form' );" />
                <label rsf:id="msg=viewreport.groups.select.newReportStyle.label" for="newReportStyle"></label>
            </div>
-           <p class="instruction" rsf:id="msg=viewreport.groups.select.newReportStyle.explanation"></p>
+           <p class="instructionText" rsf:id="msg=viewreport.groups.select.newReportStyle.explanation"></p>
         </form>
 
          <div class="individualExports">
@@ -98,7 +98,7 @@
              You do not have permissions to view this page.
          </div>
 
-         <p class="instruction" rsf:id="selectedGroups">Viewing Groups: Chemistry, Biology, and Biomed</p>
+         <p class="instructionText" rsf:id="selectedGroups">Viewing Groups: Chemistry, Biology, and Biomed</p>
 
          <!-- this BEGINS the category section -->
          <div rsf:id="categorySection:">

--- a/sakai-evaluation-tool/src/webapp/content/templates/report_view.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/report_view.html
@@ -39,11 +39,11 @@
 	<div class="portletBody">
         <div rsf:id="navIntraTool:" class="navIntraTool"/>
          
-         <ul class="breadCrumb" style="clear:both;height:1.5em;">
-         	<li style="float:left"><a rsf:id="summary-link" href="summary.html">Summary</a></li>
-         	<li style="float:left"><a rsf:id="report-groups-title" href="report_groups.html">Choose Report Groups</a></li>
-         	<li rsf:id="view-report-title" style="float:left" class="lastCrumb">View Report</li>
-            <li style="float:right" class="lastCrumb"><a rsf:id="viewItemsFilterLink" href="#" class="goToList">View Written Responses Only</a></li>
+         <ul class="breadCrumb">
+         	<li><a rsf:id="summary-link" href="summary.html">Summary</a></li>
+         	<li><a rsf:id="report-groups-title" href="report_groups.html">Choose Report Groups</a></li>
+         	<li rsf:id="view-report-title" class="lastCrumbNoFloat">View Report</li>
+            <li class="lastCrumb"><a rsf:id="viewItemsFilterLink" href="#" class="goToList">View Written Responses Only</a></li>
         </ul>
 
         <form rsf:id="evalReportForm" name="eval_report_form" method="post">
@@ -87,7 +87,7 @@
          </div>
 
          <div rsf:id="message-for:*" class="alertMessage">
-         	<ul style="margin:0px;">
+         	<ul>
          		<li>Message for user here</li>
          	</ul>
          </div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/show_eval_category.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/show_eval_category.html
@@ -39,7 +39,7 @@
 		
 		
 			<h3 rsf:id="eval-category">Category name</h3>
-			<p rsf:id="eval-category-instructions" class="instruction">
+			<p rsf:id="eval-category-instructions" class="instructionText">
 				Click on the group title link to fill out an evaluation
 			</p>
 			<div class="itemListNew">

--- a/sakai-evaluation-tool/src/webapp/content/templates/show_eval_category.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/show_eval_category.html
@@ -32,7 +32,7 @@
 	<div class="portletBody">
 		
 		<div rsf:id="message-for:*" class="alertMessage">
-			<ul style="margin:0px;">
+			<ul>
 				<li>Message for user here</li>
 			</ul>
 		</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/summary.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/summary.html
@@ -39,17 +39,17 @@
   <div class="portletBody dashboard">
     <div rsf:id="navIntraTool:" class="navIntraTool" />
 
-    <ul class="breadCrumb" rsf:id="toolsBox:" style="clear: both; height: 1.5em">
-      <li class="lastCrumb" style="float: right">
+    <ul class="breadCrumb" rsf:id="toolsBox:">
+      <li class="lastCrumb">
         <a href="evaluation_start.html" rsf:id="beginEvaluationLink" class="addItem">New Evaluation</a>
       </li>
-      <li class="lastCrumb" style="float: right">
+      <li class="lastCrumb">
         <a href="template_title_desc.html" rsf:id="createTemplateLink" class="addItem">New Template</a>
       </li>
     </ul>
 
     <div rsf:id="message-for:*" class="alertMessage">
-      <ul style="margin: 0px;">
+      <ul>
         <li>Message for user here</li>
       </ul>
     </div>
@@ -64,7 +64,7 @@
       <p rsf:id="evaluationsNone" class="instructionText indnt2">No evaluations to take</p>
 
       <div rsf:id="evaluationsList:" class="innerPanel">
-        <table id="summary-table">
+        <table class="evalsysTable">
           <thead>
             <tr>
               <th rsf:id="msg=summary.evaluations.evaluation.title" style="white-space: normal;">Evaluation</th>
@@ -74,7 +74,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr rsf:id="evaluationsCourseList:" class="userPermsRow">
+            <tr rsf:id="evaluationsCourseList:">
               <td>
                 <a rsf:id="evaluationCourseLink" href="take_eval.html">Course Title</a>
                 <span rsf:id="evaluationCourseLink_disabled" />
@@ -102,14 +102,14 @@
             <span rsf:id="summary-be-evaluated-progress-none" class="no-evals-display instructionText"></span>
         </div>
         <div rsf:id="evaluatedInProgress:" class="evaluated_in_progress">
-          <table rsf:id="evalResponseTable:" class="beEvaluatedInProgressTable tablesorter listHier lines nolines" cellspacing="0" cellpadding="0" width="99%" border="0">
+          <table rsf:id="evalResponseTable:" class="beEvaluatedInProgressTable tablesorter evalsysTable">
             <thead>
               <tr>
-                <th class="column" rsf:id="msg=summary.evaluations.evaluation.title">Evaluation</th>
-                <th class="column" rsf:id="msg=summary.evaluations.starts.title">Open</th>
-                <th class="column" rsf:id="msg=summary.evaluations.ends.title">Close</th>
-                <th class="column" rsf:id="msg=summary.responses.responses">Responses</th>
-                <th class="column" rsf:id="msg=summary.responses.results">Results</th>
+                <th rsf:id="msg=summary.evaluations.evaluation.title">Evaluation</th>
+                <th rsf:id="msg=summary.evaluations.starts.title">Open</th>
+                <th rsf:id="msg=summary.evaluations.ends.title">Close</th>
+                <th rsf:id="msg=summary.responses.responses">Responses</th>
+                <th rsf:id="msg=summary.responses.results">Results</th>
               </tr>
             </thead>
             <tbody>
@@ -143,14 +143,14 @@
             <span rsf:id="summary-be-evaluated-closed-none" class="no-evals-display instructionText"></span>
         </div>
         <div rsf:id="evaluatedClosed:" class="evaluated_closed">
-          <table rsf:id="evalResponseTable:" class="beEvaluatedClosedTable tablesorter listHier lines nolines" cellspacing="0" cellpadding="0" width="99%" border="0">
+          <table rsf:id="evalResponseTable:" class="beEvaluatedClosedTable tablesorter evalsysTable">
             <thead>
               <tr>
-                <th class="column" rsf:id="msg=summary.evaluations.evaluation.title">Evaluation</th>
-                <th class="column" rsf:id="msg=summary.evaluations.starts.title">Opens</th>
-                <th class="column" rsf:id="msg=summary.evaluations.ends.title">Closes</th>
-                <th class="column" rsf:id="msg=summary.responses.responses">Responses</th>
-                <th class="column" rsf:id="msg=summary.responses.results">Results</th>
+                <th rsf:id="msg=summary.evaluations.evaluation.title">Evaluation</th>
+                <th rsf:id="msg=summary.evaluations.starts.title">Opens</th>
+                <th rsf:id="msg=summary.evaluations.ends.title">Closes</th>
+                <th rsf:id="msg=summary.responses.responses">Responses</th>
+                <th rsf:id="msg=summary.responses.results">Results</th>
               </tr>
             </thead>
             <tbody>
@@ -211,7 +211,7 @@
              - if notifications have a "type" and expect an "action" both of these should be reclected in the UI - that is,
                 a user would need to know what the link does without clicking on it...
         -->
-        <table cellspacing="0" cellpadding="0" width="99%" border="0" class="listHier lines nolines">
+        <table class="evalsysTable">
           <tr>
             <th rsf:id="notification-title-title">Title</th>
             <th rsf:id="notification-from-title">From</th>

--- a/sakai-evaluation-tool/src/webapp/content/templates/summary.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/summary.html
@@ -55,13 +55,13 @@
     </div>
 
     <h3 rsf:id="msg=summary.page.title">Evaluations dashboard</h3>
-    <p rsf:id="msg=summary.page.instruction" class="instruction">Quick links to evaluation items</p>
-    <p rsf:id="instructor-instructions" class="instruction"></p>
+    <p rsf:id="msg=summary.page.instruction" class="instructionText">Quick links to evaluation items</p>
+    <p rsf:id="instructor-instructions" class="instructionText"></p>
 
     <div rsf:id="evaluationsBox:" class="summaryBox">
       <h4 rsf:id="msg=summary.evaluations.title">Current evaluations I need to take</h4>
 
-      <p rsf:id="evaluationsNone" class="instruction indnt2">No evaluations to take</p>
+      <p rsf:id="evaluationsNone" class="instructionText indnt2">No evaluations to take</p>
 
       <div rsf:id="evaluationsList:" class="innerPanel">
         <table cellspacing="0" cellpadding="0" width="99%" border="0" class="listHier  lines nolines">
@@ -99,7 +99,7 @@
       <div class="innerPanel">
         <div rsf:id="summary-be-evaluated-progress-header:" class="inProgressEvals">
             <span rsf:id="msg=summary.evaluated.inprogress" class="sub-heading">In Progress</span>
-            <span rsf:id="summary-be-evaluated-progress-none" class="no-evals-display instruction"></span>
+            <span rsf:id="summary-be-evaluated-progress-none" class="no-evals-display instructionText"></span>
         </div>
         <div rsf:id="evaluatedInProgress:" class="evaluated_in_progress">
           <table rsf:id="evalResponseTable:" class="beEvaluatedInProgressTable tablesorter listHier lines nolines" cellspacing="0" cellpadding="0" width="99%" border="0">
@@ -140,7 +140,7 @@
 
         <div rsf:id="summary-be-evaluated-closed-header:" class="closedEvals">
             <span rsf:id="msg=summary.evaluated.closed" class="sub-heading">Closed</span>
-            <span rsf:id="summary-be-evaluated-closed-none" class="no-evals-display instruction"></span>
+            <span rsf:id="summary-be-evaluated-closed-none" class="no-evals-display instructionText"></span>
         </div>
         <div rsf:id="evaluatedClosed:" class="evaluated_closed">
           <table rsf:id="evalResponseTable:" class="beEvaluatedClosedTable tablesorter listHier lines nolines" cellspacing="0" cellpadding="0" width="99%" border="0">
@@ -193,20 +193,20 @@
             <span rsf:id="evaluatedListTitle">Site/Group Title</span>
           </li>
         </ol>
-        <p rsf:id="evaluatedListNone" class="instruction indnt2">No items to list</p>
+        <p rsf:id="evaluatedListNone" class="instructionText indnt2">No items to list</p>
         <h5 rsf:id="sitelisting-evaluate-text">Sites you can evaluate:</h5>
         <ol class="summaryEvaluateList">
           <li rsf:id="evaluateList:">
             <span rsf:id="evaluateListTitle">Site/Group Title</span>
           </li>
         </ol>
-        <p rsf:id="evaluateListNone" class="instruction indnt2">No items to list</p>
+        <p rsf:id="evaluateListNone" class="instructionText indnt2">No items to list</p>
       </div>
     </div>
     <div rsf:id="notificationsBox:" class="summaryBox">
       <h4 rsf:id="notifications-title">Notifications</h4>
       <div class="innerPanel">
-        <p rsf:id="notifications-higher-level" class="instruction">An evaluation has been assigned from a higher level:</p>
+        <p rsf:id="notifications-higher-level" class="instructionText">An evaluation has been assigned from a higher level:</p>
         <!-- // gsilver: reformatted table to 4 cols, added placeholder rsf:id for things
              - if notifications have a "type" and expect an "action" both of these should be reclected in the UI - that is,
                 a user would need to know what the link does without clicking on it...

--- a/sakai-evaluation-tool/src/webapp/content/templates/summary.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/summary.html
@@ -64,18 +64,18 @@
       <p rsf:id="evaluationsNone" class="instructionText indnt2">No evaluations to take</p>
 
       <div rsf:id="evaluationsList:" class="innerPanel">
-        <table cellspacing="0" cellpadding="0" width="99%" border="0" class="listHier  lines nolines">
+        <table id="summary-table">
           <thead>
             <tr>
-              <th class="column" rsf:id="msg=summary.evaluations.evaluation.title" style="white-space: normal;">Evaluation</th>
-              <th class="column" rsf:id="msg=summary.evaluation.status.title">Status</th>
-              <th class="column" rsf:id="msg=summary.evaluations.starts.title">Opens</th>
-              <th class="column" rsf:id="msg=summary.evaluations.ends.title">Closes</th>
+              <th rsf:id="msg=summary.evaluations.evaluation.title" style="white-space: normal;">Evaluation</th>
+              <th rsf:id="msg=summary.evaluation.status.title">Status</th>
+              <th rsf:id="msg=summary.evaluations.starts.title">Opens</th>
+              <th rsf:id="msg=summary.evaluations.ends.title">Closes</th>
             </tr>
           </thead>
           <tbody>
-            <tr rsf:id="evaluationsCourseList:">
-              <td style="width: 20em">
+            <tr rsf:id="evaluationsCourseList:" class="userPermsRow">
+              <td>
                 <a rsf:id="evaluationCourseLink" href="take_eval.html">Course Title</a>
                 <span rsf:id="evaluationCourseLink_disabled" />
               </td>

--- a/sakai-evaluation-tool/src/webapp/content/templates/take_eval.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/take_eval.html
@@ -87,12 +87,12 @@
         </div>
         <div class="alertMessage" rsf:id="saveEvaluationWithoutSubmitWarning">Evaluation has been Saved but not Submitted</div>
 
-		<div rsf:id="show-eval-instructions:" class="instruction">
+		<div rsf:id="show-eval-instructions:" class="instructionText">
 			<h5 rsf:id="eval-instructions-header" style="display:inline;padding-right:1em">Instructions:</h5>
 			<span rsf:id="eval-instructions">Evaluation instructions would go here if any have been specified. This block may be up to 4000 chars.</span>
 		</div>
 
-		<div rsf:id="show-eval-note:" class="instruction">
+		<div rsf:id="show-eval-note:" class="instructionText">
 		   <h5 rsf:id="msg=general.note"  style="display:inline;padding-right:1em">Note:</h5>
 		   <div rsf:id="eval-note-text" style="display:inline">Additional instructional note to the user here</div>
 		</div>

--- a/sakai-evaluation-tool/src/webapp/content/templates/take_eval.html
+++ b/sakai-evaluation-tool/src/webapp/content/templates/take_eval.html
@@ -81,7 +81,7 @@
 		</div>
 
         <div rsf:id="message-for:*" class="alertMessage">
-            <ul style="margin:0px;">
+            <ul>
                 <li>Message for user here</li>
             </ul>
         </div>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/EVALSYS-1475

* When taking an evaluation, question text was not visible (white), it has been changed to black
* Administrate -> Control Eval Admins UI navbar is styled/structured incorrectly (this is a historical problem, not really related to Morpheus)
* Checkboxes are misaligned (run off the left hand side of the 'page')
* Fieldsets/legends look bad
* In-line "Copy" buttons have some styling issues (text alignment, padding)
* Remove the navBar from certain interfaces that are presented in a modal dialogue (ex, remove item)
* Headers are misaligned in modal dialogues
* The 'X' button to close modal dialogues is misaligned
* No 'Cancel' button on the edit item modal dialogue
* Table header text is the same size/weight as table content text
* Table header row has same background colour as odd numbered table content row's background
* class="instruction" used heavily throughout, however the underlying styles of that class has changed significantly. As such, it is no longer appropriate for use in many of the places it's currently being employed in EvalSys
** The most significant changes is that this class is now a block element, so any places where this was used in-line now creates a block level element, and it moves things around quite a bit
* "My Scales" -> header rows aren't tall enough, rendering the content links and buttons almost unclickable
* Consolidate styles for tables (in-line and in CSS)
* Remove hard coded nbsp's from hierarchy markup files (there's too many in the project to do them all right now)