### PR TITLE
EVALSYS-1482: retrieve assigned eval groups from the database

### DIFF
--- a/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/externals/ExternalHierarchyLogicImpl.java
+++ b/sakai-evaluation-impl/src/java/org/sakaiproject/evaluation/logic/externals/ExternalHierarchyLogicImpl.java
@@ -520,6 +520,14 @@ public class ExternalHierarchyLogicImpl implements ExternalHierarchyLogic {
         Set<String> groups = new HashSet<>();
         try
         {
+            EvalGroupNodes egn = getEvalGroupNodeByNodeId(nodeID);
+            if (egn != null) {
+                String[] evalGroups = egn.getEvalGroups();
+                for (int i = 0; i < evalGroups.length; i++) {
+                    groups.add(evalGroups[i]);
+                }
+            }
+
             List<HierarchyNodeRule> rules = getRulesByNodeID( Long.parseLong( nodeID ) );
             for( HierarchyNodeRule rule : rules )
             {


### PR DESCRIPTION
Here's a fix I'm testing out right now here at HEC Montreal.  This is an important issue for us because we have a Quartz job that builds our evaluations hierarchy and calls the method setEvalGroupsForNode() to assign groups.  

I'm not sure if this conflicts with assigning evaluations to sections, but so far it seems to be working alright for our use-case.