### PR TITLE
EVALSYS-1484 fix behaviour of 'return to your home' and 'logout' buttons for students/access members

### DIFF
--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages.properties
@@ -111,7 +111,7 @@ summary.label.Active=Due
 summary.label.Due=Closes
 summary.label.Closed=Viewable
 summary.label.Viewable=Viewable since
-summary.myworkspace.link.label=Return to your My Workspace
+summary.myworkspace.link.label=Return to your Home
 summary.logout.link.label=Logout of {0}
 
 # Administrate view

--- a/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_en_GB.properties
+++ b/sakai-evaluation-tool/src/java/org/sakaiproject/evaluation/tool/bundle/messages_en_GB.properties
@@ -52,7 +52,7 @@ summary.label.gracetill=Closes
 summary.label.resultsviewableon=Viewable
 summary.label.resultsviewablesince=Viewable since
 summary.label.fallback=Starts
-summary.myworkspace.link.label=Return to your My Workspace
+summary.myworkspace.link.label=Return to your Home
 summary.logout.link.label=Logout of {0}
 
 # Administrate view


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/EVALSYS-1484

I was able to solve this by using a UIFreeAttributeDecorator to add the target="_parent" to the links. They now behave as expected. I've also added the following sakai.property for institutions that don't want to see the links at all (which defaults to true, so you need to set it to false explicitly in order to hide the links):

evalsys.enable.extra.student.links

Tidied up some whitespace inconsistencies in the file while I was there.... OCD. The relevant changes are between lines 104 and 116.