### PR TITLE
EVALSYS-1512 : New evaluation start time setting

### DIFF
--- a/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/beans/EvalBeanUtils.java
+++ b/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/beans/EvalBeanUtils.java
@@ -245,6 +245,18 @@ public class EvalBeanUtils {
         // make sure the dates are set
         Calendar calendar = new GregorianCalendar();
         Date now =  new Date();
+
+        // if default start hour is set, use it for start time (must be tomorrow as eval cannot start in the past).
+        Integer hour = (Integer) settings.get(EvalSettings.EVAL_DEFAULT_START_HOUR);
+        if (hour != null) {
+            // add 1 day to make it tomorrow
+            now.setTime(now.getTime() + 86400000L);
+            // set desired hour
+            now.setHours(hour);
+            now.setMinutes(0);
+            now.setSeconds(0);
+        }
+
         calendar.setTime( now );
         if (eval.getStartDate() == null) {
             eval.setStartDate(now);

--- a/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/logic/EvalSettings.java
+++ b/sakai-evaluation-api/src/java/org/sakaiproject/evaluation/logic/EvalSettings.java
@@ -228,6 +228,11 @@ public interface EvalSettings {
     public static final String EVAL_USE_DATE_TIME = "EVAL_USE_DATE_TIME:java.lang.Boolean";
 
     /**
+     * CONSTANT: Define default start hour for new evaluation - {@link Integer}, default current time<br/>
+     */
+    public static final String EVAL_DEFAULT_START_HOUR = "EVAL_DEFAULT_START_HOUR:java.lang.Integer";
+
+    /**
      * CONSTANT: Should we display Hierarchy Options and Information in the User Interface - {@link Boolean}, default False
      */
     public static final String DISPLAY_HIERARCHY_OPTIONS = "DISPLAY_HIERARCHY_OPTIONS:java.lang.Boolean";


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/EVALSYS-1512

I've implemented a new option to allow us to set a start time (as an integer, out of 24h) as a default for new evaluations. That way our administrator can just set the date and not have to change the start time.

The option EVAL_DEFAULT_START_HOUR must be inserted manually into the EVAL_CONFIG table with an integer between 1 and 24. New evaluations will have a default start time at that hour.